### PR TITLE
fix/cleanup/adjustment: flirting and dating restrictions

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2158,6 +2158,62 @@ class Cat():
             return False
 
         return True
+    
+    def is_dateable(self,
+                    other_cat: Cat,
+                    age_restriction: bool = True,
+                    ignore_no_mates: bool = False
+                    ):
+
+        """
+            LifeGen-specific function to see if a cat can be dated/flirted with.
+            Heavily based on is_potential_mate with some key differences.
+            The age limit is 12 moons instead of 14 since the player is allowed to make that choice.
+            Adolescents are allowed to flirt with each other.
+            This function should not be used in place of is_potential_mate.
+        """
+        
+        # check to make sure it's not the same cat
+
+        if self.ID == other_cat.ID:
+            return False
+        
+        # no mates check - can be commented out if it's desired to allow MCs to flirt with/date cats regardless of their romantic interactions being limited
+
+        if not ignore_no_mates and (self.no_mates or other_cat.no_mates):
+            return False
+        
+        # make sure the cat isn't too closely related
+
+        if self.is_related(other_cat, game.clan.clan_settings["first cousin mates"]):
+            return False
+        
+        # make sure they're not outside the clan or dead
+
+        if self.dead or other_cat.dead or self.outside or other_cat.outside:
+            return False
+        
+        # check age. allow adolescents to flirt with each other. prevent kittens and newborns from flirting
+
+        if age_restriction:
+            if (self.moons < 12 or other_cat.moons < 12):
+                if self.age in ["adolescent"] or other_cat.age in ["adolescent"]:
+                    if self.age != other_cat.age:
+                        return False
+            if self.age in ["newborn", "kitten"] or other_cat.age in ["newborn", "kitten"]:
+                return False
+            
+            if game.config["mates"].get("override_same_age_group", False) or self.age != other_cat.age:
+                if abs(self.moons - other_cat.moons)> game.config["mates"]["age_range"] + 1:
+                    return False
+        
+        # check for mentor
+
+        is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices or other_cat.ID in self.apprentice or self.ID in other_cat.apprentice)
+        if is_former_mentor and not game.clan.clan_settings['romantic with former mentor']:
+            return False
+        
+        return True
 
     def unset_mate(self, other_cat: Cat, breakup: bool = False, fight: bool = False):
         """Unset the mate from both self and other_cat"""

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2153,7 +2153,7 @@ class Cat():
                 return False
 
         # check for mentor
-        is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices or other_cat.ID in self.apprentice or self.ID in other_cat.apprentice)
+        is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices)
         if is_former_mentor and not game.clan.clan_settings['romantic with former mentor']:
             return False
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2209,7 +2209,7 @@ class Cat():
         
         # check for mentor
 
-        is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices or other_cat.ID in self.apprentice or self.ID in other_cat.apprentice)
+        is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices)
         if is_former_mentor and not game.clan.clan_settings['romantic with former mentor']:
             return False
         if other_cat.ID in self.apprentice or self.ID in other_cat.apprentice:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2212,6 +2212,8 @@ class Cat():
         is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices or other_cat.ID in self.apprentice or self.ID in other_cat.apprentice)
         if is_former_mentor and not game.clan.clan_settings['romantic with former mentor']:
             return False
+        if other_cat.ID in self.apprentice or self.ID in other_cat.apprentice:
+            return False
         
         return True
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2153,6 +2153,11 @@ class Cat():
                 return False
 
         # check for mentor
+
+        # Current mentor
+        if other_cat.ID in self.apprentice or self.ID in other_cat.apprentice:
+            return False
+        
         is_former_mentor = (other_cat.ID in self.former_apprentices or self.ID in other_cat.former_apprentices)
         if is_former_mentor and not game.clan.clan_settings['romantic with former mentor']:
             return False

--- a/scripts/screens/DatePatrolScreen.py
+++ b/scripts/screens/DatePatrolScreen.py
@@ -647,9 +647,7 @@ class DatePatrolScreen(Screens):
             game.switches['patrolled'] = []
         if not you.dead and "4" not in game.switches['patrolled'] and not you.outside and not you.not_working():
             for the_cat in Cat.all_cats_list:
-                if not the_cat.dead and the_cat.in_camp and the_cat.ID not in game.patrolled and the_cat.status not in [
-                    'newborn', 'kitten', 'apprentice', 'mediator apprentice', 'medicine cat apprentice', "queen's apprentice"
-                ] and not the_cat.outside and the_cat not in self.current_patrol and the_cat.is_potential_mate(game.clan.your_cat) and the_cat.moons < game.clan.your_cat.moons + 40 and the_cat.moons > game.clan.your_cat.moons - 40:
+                if the_cat.in_camp and the_cat.ID not in game.patrolled and the_cat not in self.current_patrol and the_cat.is_dateable(game.clan.your_cat):
                     self.able_cats.append(the_cat)
 
         if not self.able_cats:

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -713,13 +713,9 @@ class ProfileScreen(Screens):
                     self.profile_elements["insult"].disable()
                 else:
                     self.profile_elements["insult"].enable()
-            is_former_mentor = (self.the_cat.ID in game.clan.your_cat.former_apprentices or game.clan.your_cat.ID in self.the_cat.former_apprentices)
-            no_flirt = False
-            if is_former_mentor:
-                if not game.clan.clan_settings['romantic with former mentor']:
-                    no_flirt = True 
-            if (self.the_cat.ID not in game.clan.your_cat.get_relatives() and not no_flirt and self.the_cat.moons >= 12 and self.the_cat.moons < game.clan.your_cat.moons + 40 and self.the_cat.moons > game.clan.your_cat.moons - 40 and game.clan.your_cat.moons >= 12) or self.the_cat.ID in game.clan.your_cat.mate:
-                if not self.the_cat.dead and not self.the_cat.outside and self.the_cat.status not in ['leader', 'mediator', 'mediator apprentice']:
+                    
+            if self.the_cat.is_dateable(game.clan.your_cat):
+                if self.the_cat.status not in ['leader', 'mediator', 'mediator apprentice']:
                     self.profile_elements["flirt"] = UIImageButton(scale(pygame.Rect(
                         (646, 220), (68, 68))),
                         "",
@@ -730,30 +726,7 @@ class ProfileScreen(Screens):
                         self.profile_elements["flirt"].disable()
                     else:
                         self.profile_elements["flirt"].enable()
-                elif not self.the_cat.dead and not self.the_cat.outside and self.the_cat.status in ['leader', 'mediator', 'mediator apprentice']:
-                    self.profile_elements["flirt"] = UIImageButton(scale(pygame.Rect(
-                        (910, 220), (68, 68))),
-                        "",
-                        object_id="#flirt_button",
-                        tool_tip_text="Flirt with this Cat", manager=MANAGER
-                    )
-                    if self.the_cat.flirted:
-                        self.profile_elements["flirt"].disable()
-                    else:
-                        self.profile_elements["flirt"].enable()
-            elif self.the_cat.ID not in game.clan.your_cat.get_relatives() and game.clan.your_cat.status in ['apprentice', 'medicine cat apprentice', 'mediator apprentice', "queen's apprentice"] and self.the_cat.status in ['apprentice', 'medicine cat apprentice', 'mediator apprentice', "queen's apprentice"]:
-                if not self.the_cat.dead and not self.the_cat.outside and self.the_cat.status not in ['mediator apprentice']:
-                    self.profile_elements["flirt"] = UIImageButton(scale(pygame.Rect(
-                        (646, 220), (68, 68))),
-                        "",
-                        object_id="#flirt_button",
-                        tool_tip_text="Flirt with this Cat", manager=MANAGER
-                    )
-                    if self.the_cat.flirted:
-                        self.profile_elements["flirt"].disable()
-                    else:
-                        self.profile_elements["flirt"].enable()
-                elif not self.the_cat.dead and not self.the_cat.outside and self.the_cat.status in ['mediator apprentice']:
+                elif self.the_cat.status in ['leader', 'mediator', 'mediator apprentice']:
                     self.profile_elements["flirt"] = UIImageButton(scale(pygame.Rect(
                         (910, 220), (68, 68))),
                         "",


### PR DESCRIPTION
condensed the code that determined whether a cat could be flirted with or taken on a date into a new function located within cats.py, is_dateable.

is_dateable is quite similar to is_potential_mate, with a few differences to allow for player agency and to give freedom in editing the function without messing with is_potential_mate.

previously, flirting was reliant on rank rather than age in certain situations, which could potentially lead to uncomfortable situations such as a 6 moon old being able to flirt with a 15 moon old if they were both apprentices. if i'm wrong about this then...well, the code was very confusing, so this should make it clearer at least.

on the other hand, dating used is_potential_mate, which would lead to odd situations such as being able to flirt with cats at 12 moons old but not take them on dates until 14 moons, even if they were your mate.

now, both dating and flirting rely on is_dateable. if a cat is between 6-11 moons in age they should only be able to flirt with other 6-11 moon olds now. once a cat reaches 12 moons old, they can flirt with or date any cats that fall within the age range denoted in game_config, provided of course that those cats are older than 11 moons,  not relatives, and (if the setting to allow this is turned off) not former mentors/apprentices. cats may never flirt with or date current mentors/apprentices.

personally i would suggest maybe taking off the restriction for dating that the cat must not be in game.patrolled because sometimes you wanna take your spouse on a date after work, but i have left that as it is for right now.