### PR TITLE
fix: adjust paths to avoid crashing on macOS, Linux and other *nix OSes

### DIFF
--- a/scripts/screens/StartScreen.py
+++ b/scripts/screens/StartScreen.py
@@ -46,7 +46,7 @@ class StartScreen(Screens):
     def __init__(self, name=None):
         super().__init__(name)
         self.warning_label = None
-        bg = self.choose_random_menu("resources\menus")
+        bg = self.choose_random_menu("resources/menus")
         self.bg = pygame.image.load(bg).convert()
         self.bg = pygame.transform.scale(self.bg, (screen_x, screen_y))
         self.social_buttons = {}
@@ -59,9 +59,9 @@ class StartScreen(Screens):
 
         if png_files:
             chosen_file = random.choice(png_files)
-            return "resources\\menus\\" + chosen_file
+            return "resources/menus/" + chosen_file
         else:
-            return "resources\\images\\menu.png"
+            return "resources/images/menu.png"
 
     def handle_event(self, event):
         """This is where events that occur on this page are handled.


### PR DESCRIPTION
The code to load the menu art used incorrectly formatted paths for macOS, Linux and other *nix-OS by using backslashes `\` in place of regular forward slashes `/`. This fixes that, allowing the game to work again on non-Windows OS.