### PR TITLE
Df Patrol + Dialogue updates

### DIFF
--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -15084,6 +15084,56 @@
             "We were supposed to be Clanmates."
         ]
     ],
+    "murderedthem3": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned"
+        ],
+        [
+            "I hope they exile you.",
+            "I'd say I hope they kill you, but I don't want you up here with me."
+        ]
+    ],
+    "murderedthem4": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned"
+        ],
+        [
+            "I hope they exile you.",
+            "I'd say I hope they kill you, but I don't want you up here with me."
+        ]
+    ],
+    "murderedthem5": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "I hope they exile you.",
+            "I'd say I hope they kill you, but I don't want you up here with me."
+        ]
+    ],
+    "murderedthem6": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "I hope they exile you.",
+            "I'd say I hope they kill you, but I don't want you up here with me."
+        ]
+    ],
     "murderedyou1": [
         [
             "murderedyou",

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -15222,5 +15222,14 @@
         [
             "I'm sorry. I really am."
         ]
+    ],
+    "youforgiven1": [
+        [
+            "you_forgiven",
+            "any"
+        ],
+        [
+            "Don't think the Clan will forget what you did."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -14851,7 +14851,7 @@
         ],
         [
             "Clanmates ignoring you, huh?",
-            "Get used to it. That's just a little taste fo what you're in for when you get here."
+            "Get used to it. That's just a little taste of what you're in for when you get here."
         ]
     ],
     "dead_youshunned2":
@@ -14889,6 +14889,63 @@
         ],
         [
             "You poor thing..."
+        ]
+    ],
+    "dead_youshunned5":
+    [
+        [
+            "they_df",
+            "you_shunned",
+            "any",
+            "they_older"
+        ],
+        [
+            "You're doing a good job down there.",
+            "That cat was asking for it. I'd have killed the rest of them too, if I were you.",
+            "c_nClan is full of mouse-hearts these days.",
+            "Not you, though!"
+        ]
+    ],
+    "dead_youshunned6":
+    [
+        [
+            "they_df",
+            "you_shunned",
+            "medicine cat apprentice",
+            "apprentice",
+            "mediator apprentice",
+            "queen's apprentice",
+            "they_older"
+        ],
+        [
+            "Wait, so, they really made you stop your training because you killed one cat?",
+            "That's ridiculous.",
+            "You're strong. They need you. They'll come around."
+        ]
+    ],
+    "dead_youshunned7":
+    [
+        [
+            "they_df",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "It's more fun here than it is in the waking world, isn't it?",
+            "Aah, don't lie! I see it in your eyes!"
+        ]
+    ],
+    "dead_youshunned8":
+    [
+        [
+            "they_df",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "You really killed another cat?",
+            "Huh. Maybe you're not as mouse-hearted as I thought.",
+            "No, you're still a mouse-heart, just... not as big of one."
         ]
     ],
     "sc_living_kitten": [

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -15061,5 +15061,116 @@
             "Do you... get a lot of sleep, y_c?",
             "You always look exhausted."
         ]
+    ],
+    "murderedthem1": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc"
+        ],
+        [
+            "Don't talk to me, traitor.",
+            "We were supposed to be Clanmates."
+        ]
+    ],
+    "murderedthem2": [
+        [
+            "murderedthem",
+            "any",
+            "they_df"
+        ],
+        [
+            "Don't talk to me, traitor.",
+            "We were supposed to be Clanmates."
+        ]
+    ],
+    "murderedyou1": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc"
+        ],
+        [
+            "Oh, yikes, I'm still going to have to deal with you after death?"
+        ]
+    ],
+    "murderedyou2": [
+        [
+            "murderedyou",
+            "any",
+            "you_df"
+        ],
+        [
+            "Oh, yikes, I'm still going to have to deal with you after death?"
+        ]
+    ],
+    "murderedyou3": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_df"
+        ],
+        [
+            "How did you make it into StarClan?",
+            "You deserved what happened to you and more.",
+            "If I could kill you again, I would."
+        ]
+    ],
+    "murderedyou4": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_df"
+        ],
+        [
+            "Oh, don't look so scared.",
+            "I can't kill you again."
+        ]
+    ],
+    "murderedyou5": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyou6": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyou7": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyou8": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -15024,7 +15024,7 @@
             "Please."
         ]
     ],
-    "dftrainee1": [
+    "dftrainee_J1": [
         [
             "they_df",
             "you_dftrainee",
@@ -15038,7 +15038,7 @@
             "... Good. See you there."
         ]
     ],
-    "dftrainee2": [
+    "dftrainee_J2": [
         [
             "they_df",
             "you_dftrainee",
@@ -15052,7 +15052,7 @@
             "Tch. Whatever. Come find me when you've grown a spine."
         ]
     ],
-    "dftrainee3": [
+    "dftrainee_J3": [
         [
             "you_dftrainee",
             "any"
@@ -15062,7 +15062,7 @@
             "You always look exhausted."
         ]
     ],
-    "murderedthem1": [
+    "murderedthem_J1": [
         [
             "murderedthem",
             "any",
@@ -15073,7 +15073,7 @@
             "We were supposed to be Clanmates."
         ]
     ],
-    "murderedthem2": [
+    "murderedthem_J2": [
         [
             "murderedthem",
             "any",
@@ -15084,7 +15084,7 @@
             "We were supposed to be Clanmates."
         ]
     ],
-    "murderedthem3": [
+    "murderedthem_J3": [
         [
             "murderedthem",
             "any",
@@ -15096,7 +15096,7 @@
             "I'd say I hope they kill you, but I don't want you up here with me."
         ]
     ],
-    "murderedthem4": [
+    "murderedthem_J4": [
         [
             "murderedthem",
             "any",
@@ -15108,7 +15108,7 @@
             "I'd say I hope they kill you, but I don't want you up here with me."
         ]
     ],
-    "murderedthem5": [
+    "murderedthem_J5": [
         [
             "murderedthem",
             "any",
@@ -15121,7 +15121,7 @@
             "I'd say I hope they kill you, but I don't want you up here with me."
         ]
     ],
-    "murderedthem6": [
+    "murderedthem_J6": [
         [
             "murderedthem",
             "any",
@@ -15134,7 +15134,28 @@
             "I'd say I hope they kill you, but I don't want you up here with me."
         ]
     ],
-    "murderedyou1": [
+    "murderedthem_J7": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_forgiven"
+        ],
+        [
+            "I don't care if the Clan has forgiven you. I never will."
+        ]
+    ],
+    "murderedthem_J8": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc"
+        ],
+        [
+            "Get away from me, murderer! Don't you think you've put me through enough?"
+        ]
+    ],
+    "murderedyou_J1": [
         [
             "murderedyou",
             "any",
@@ -15144,7 +15165,7 @@
             "Oh, yikes, I'm still going to have to deal with you after death?"
         ]
     ],
-    "murderedyou2": [
+    "murderedyou_J2": [
         [
             "murderedyou",
             "any",
@@ -15154,7 +15175,7 @@
             "Oh, yikes, I'm still going to have to deal with you after death?"
         ]
     ],
-    "murderedyou3": [
+    "murderedyou_J3": [
         [
             "murderedyou",
             "any",
@@ -15167,7 +15188,7 @@
             "If I could kill you again, I would."
         ]
     ],
-    "murderedyou4": [
+    "murderedyou_J4": [
         [
             "murderedyou",
             "any",
@@ -15179,7 +15200,7 @@
             "I can't kill you again."
         ]
     ],
-    "murderedyou5": [
+    "murderedyou_J5": [
         [
             "murderedyou",
             "any",
@@ -15190,7 +15211,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "murderedyou6": [
+    "murderedyou_J6": [
         [
             "murderedyou",
             "any",
@@ -15201,7 +15222,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "murderedyou7": [
+    "murderedyou_J7": [
         [
             "murderedyou",
             "any",
@@ -15212,7 +15233,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "murderedyou8": [
+    "murderedyou_J8": [
         [
             "murderedyou",
             "any",
@@ -15223,13 +15244,68 @@
             "I'm sorry. I really am."
         ]
     ],
-    "youforgiven1": [
+    "youforgiven_J1": [
         [
             "you_forgiven",
             "any"
         ],
         [
             "Don't think the Clan will forget what you did."
+        ]
+    ],
+    "youforgiven_J2": [
+        [
+            "you_forgiven",
+            "any",
+            "sweet"
+        ],
+        [
+            "Oh, I'm so glad I get to talk to you again, y_c!",
+            "Have you been on a hunting patrol yet? Wanna go right now?",
+            "Yes! Let's go! I'm glad to have you back in the Clan."
+        ]
+    ],
+    "youforgiven_J3": [
+        [
+            "you_forgiven",
+            "any"
+        ],
+        [
+            "[Though you've been forgiven by the Clan, t_c still doesn't seem to trust you.]",
+            "What? Am I staring?",
+            "Sorry. Wouldn't want to be next on your list..."
+        ]
+    ],
+    "youforgiven_J4": [
+        [
+            "you_forgiven",
+            "they_forgiven",
+            "any"
+        ],
+        [
+            "[t_c is one of the only cats in the Clan that treats you normally. You're glad you have a cat who understands what you're going through.]",
+            "These cats are so dramatic.",
+            "Don't worry, they're forget soon enough and life will be back to normal.",
+            "[They seem to be trying to convince themselves of this fact just as much as you.]"
+        ]
+    ],
+    "they_forgiven_J1": [
+        [
+            "they_forgiven",
+            "any"
+        ],
+        [
+            "Hey there, y_c? How's your day been?",
+            "[t_c is being extra friendly ever since their shun was lifted.]"
+        ]
+    ],
+    "they_forgiven_J2": [
+        [
+            "they_forgiven",
+            "any"
+        ],
+        [
+            "Sometimes, I miss being shunned. More cats left me alone."
         ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -3093,5 +3093,119 @@
             "... ... ... ... ...",
             "r_m has some explaining to do."
         ]
+    ],
+    "kitmurderedthem1": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
+    "kitmurderedthem2": [
+        [
+            "murderedthem",
+            "any",
+            "they_df"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
+    "murderedyoukit1": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc"
+        ],
+        [
+            "Oh, hey, y_c...",
+            "You should... go play somewhere else.",
+            "[It seems that t_c doesn't want to confront what they'd done.]"
+        ]
+    ],
+    "murderedyoukit2": [
+        [
+            "murderedyou",
+            "any",
+            "you_df"
+        ],
+        [
+            "Oh, hey, y_c...",
+            "You should... go play somewhere else.",
+            "[It seems that t_c doesn't want to confront what they'd done.]"
+        ]
+    ],
+    "murderedyoukit3": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_df"
+        ],
+        [
+            "Oh, hey, y_c...",
+            "You should... go play somewhere else.",
+            "[It seems that t_c doesn't want to confront what they'd done.]"
+        ]
+    ],
+    "murderedyoukit4": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_df"
+        ],
+        [
+            "Oh, hey, y_c...",
+            "You should... go play somewhere else.",
+            "[It seems that t_c doesn't want to confront what they'd done.]"
+        ]
+    ],
+    "murderedyoukit5": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyoukit6": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyoukit7": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyoukit8": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -3114,6 +3114,52 @@
             "What an evil little thing."
         ]
     ],
+    "kitmurderedthem3": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
+    "kitmurderedthem4": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
+    "kitmurderedthem5": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
+    "kitmurderedthem6": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "What an evil little thing."
+        ]
+    ],
     "murderedyoukit1": [
         [
             "murderedyou",

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -4441,6 +4441,52 @@
             "Did I do something wrong?"
         ]
     ],
+    "murderedthemkit3": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
+    "murderedthemkit4": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
+    "murderedthemkit5": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
+    "murderedthemkit6": [
+        [
+            "murderedthem",
+            "any",
+            "they_df",
+            "you_shunned",
+            "you_grieving"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
     "kitmurderedyou1": [
         [
             "murderedyou",

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -3859,6 +3859,18 @@
             "I'm sure whatever you did can't be as bad as that ... right?"
         ]
     ],
+    "you_shunned_8": [
+        [
+            "you_shunned",
+            "they_kitten",
+            "kitten"
+        ],
+        [
+            "Hey, y_c!",
+            "r_c told me that no one should be friends with you because you made a bad mistake.",
+            "I'll still be your friend, though! Just don't tell r_c about it, okay?"
+        ]
+    ],
     "starclan_they_living": [
         [
             "you_sc",

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -3940,10 +3940,10 @@
             "any"
         ],
         [
-            "[t_c is tearing clumps of dirt form the ground beneath them. You ask why,]",
-            "This place sucks. I'm trying to destroy it.",
+            "[t_c is tearing clumps of dirt from the ground beneath them. You ask why.]",
+            "This place sucks! I'm trying to destroy it.",
             "I want to go live with the starry cats.",
-            "[Decide to join them. Maybe you two can dig far enough that you end up someplace new.]"
+            "[You decide to join them. Maybe you two can dig far enough that you end up someplace new.]"
         ]
     ],
     "sckit2": [
@@ -4419,6 +4419,116 @@
         [
             "It's not fair! It's not fair!",
             "Make them pay, y_c!"
+        ]
+    ],
+    "murderedthemkit1": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
+    "murderedthemkit2": [
+        [
+            "murderedthem",
+            "any",
+            "they_df"
+        ],
+        [
+            "Did I do something wrong?"
+        ]
+    ],
+    "kitmurderedyou1": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc"
+        ],
+        [
+            "Wait, you're still here?",
+            "[Startled, t_c rushes away to the nursery]"
+        ]
+    ],
+    "kitmurderedyou2": [
+        [
+            "murderedyou",
+            "any",
+            "you_df"
+        ],
+        [
+            "Wait, you're still here?",
+            "[Startled, t_c rushes away to the nursery]"
+        ]
+    ],
+    "kitmurderedyou3": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_df"
+        ],
+        [
+            "Hi, y_c.",
+            "Are you still mad at me?"
+        ]
+    ],
+    "kitmurderedyou4": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_df"
+        ],
+        [
+            "Hi, y_c.",
+            "Are you still mad at me?"
+        ]
+    ],
+    "kitmurderedyou5": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "kitmurderedyou6": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_sc"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyoukit7": [
+        [
+            "murderedyou",
+            "any",
+            "you_sc",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
+        ]
+    ],
+    "murderedyoukit8": [
+        [
+            "murderedyou",
+            "any",
+            "you_df",
+            "they_grieving"
+        ],
+        [
+            "I'm sorry. I really am."
         ]
     ]
 }

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -4421,7 +4421,7 @@
             "Make them pay, y_c!"
         ]
     ],
-    "murderedthemkit1": [
+    "murderedthemkit_J1": [
         [
             "murderedthem",
             "any",
@@ -4431,7 +4431,7 @@
             "Did I do something wrong?"
         ]
     ],
-    "murderedthemkit2": [
+    "murderedthemkit_J2": [
         [
             "murderedthem",
             "any",
@@ -4441,7 +4441,7 @@
             "Did I do something wrong?"
         ]
     ],
-    "murderedthemkit3": [
+    "murderedthemkit_J3": [
         [
             "murderedthem",
             "any",
@@ -4452,7 +4452,7 @@
             "Did I do something wrong?"
         ]
     ],
-    "murderedthemkit4": [
+    "murderedthemkit_J4": [
         [
             "murderedthem",
             "any",
@@ -4463,7 +4463,7 @@
             "Did I do something wrong?"
         ]
     ],
-    "murderedthemkit5": [
+    "murderedthemkit_J5": [
         [
             "murderedthem",
             "any",
@@ -4475,7 +4475,7 @@
             "Did I do something wrong?"
         ]
     ],
-    "murderedthemkit6": [
+    "murderedthemkit_J6": [
         [
             "murderedthem",
             "any",
@@ -4487,7 +4487,64 @@
             "Did I do something wrong?"
         ]
     ],
-    "kitmurderedyou1": [
+    "murderedthemkit_J7": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "littermate"
+        ],
+        [
+            "We were supposed to grow up together!",
+            "Why did you do that to me, y_c?"
+        ]
+    ],
+    "murderedthemkit_J8": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "littermate",
+            "you_shunned"
+        ],
+        [
+            "We were supposed to grow up together!",
+            "Why did you do that to me, y_c?"
+        ]
+    ],
+    "murderedthemkit_J9": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "littermate",
+            "you_shunned"
+        ],
+        [
+            "I wish we could've played together some more...",
+            "I guess you didn't really want to, though."
+        ]
+    ],
+    "murderedthemkit_J10": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "littermate",
+            "warrior",
+            "medicine cat",
+            "mediator",
+            "queen",
+            "deputy",
+            "leader",
+            "elder"
+        ],
+        [
+            "I've been here a really long time...",
+            "Does y_p still miss me?"
+        ]
+    ],
+    "kitmurderedyou_J1": [
         [
             "murderedyou",
             "any",
@@ -4498,7 +4555,7 @@
             "[Startled, t_c rushes away to the nursery]"
         ]
     ],
-    "kitmurderedyou2": [
+    "kitmurderedyou_J2": [
         [
             "murderedyou",
             "any",
@@ -4509,7 +4566,7 @@
             "[Startled, t_c rushes away to the nursery]"
         ]
     ],
-    "kitmurderedyou3": [
+    "kitmurderedyou_J3": [
         [
             "murderedyou",
             "any",
@@ -4521,7 +4578,7 @@
             "Are you still mad at me?"
         ]
     ],
-    "kitmurderedyou4": [
+    "kitmurderedyou_J4": [
         [
             "murderedyou",
             "any",
@@ -4533,7 +4590,7 @@
             "Are you still mad at me?"
         ]
     ],
-    "kitmurderedyou5": [
+    "kitmurderedyou_J5": [
         [
             "murderedyou",
             "any",
@@ -4544,7 +4601,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "kitmurderedyou6": [
+    "kitmurderedyou_J6": [
         [
             "murderedyou",
             "any",
@@ -4555,7 +4612,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "murderedyoukit7": [
+    "murderedyoukit_J7": [
         [
             "murderedyou",
             "any",
@@ -4566,7 +4623,7 @@
             "I'm sorry. I really am."
         ]
     ],
-    "murderedyoukit8": [
+    "murderedyoukit_J8": [
         [
             "murderedyou",
             "any",

--- a/resources/dicts/lifegen_talk/leader.json
+++ b/resources/dicts/lifegen_talk/leader.json
@@ -1950,5 +1950,18 @@
             "o_cClan has once again, overstepped some boundaries, and look- I'm not one to shudder in fear when facing other leaders- but... The deputy just became leader. And are proving to be a rather big problem. No-",
             "No I'm sorry, I shouldn't be discussing this out loud. I just- I just want to guarantee the safety of c_nClan. No matter what."
         ]
+    ],
+    "murderedthem_leader_J1": [
+        [
+            "murderedthem",
+            "any",
+            "they_sc",
+            "they_leader"
+        ],
+        [
+            "How dare you speak to me in StarClan when you have such disrespect for your ancestors?",
+            "Nine lives I was given, and you deemed yourself important enough to take the last of them.",
+            "I hope you never join me here. I'll see you in the Dark Forest one day, I promise you."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -1274,6 +1274,25 @@
             "Grr..."
         ]
     ],
+    "newborn_7_df": [
+        [
+            "Any",
+            "they_df"
+        ],
+        [
+            "Grr..."
+        ]
+    ],
+    "newborn_8_df": [
+        [
+            "Any",
+            "they_df",
+            "you_shunned"
+        ],
+        [
+            "Grr..."
+        ]
+    ],
     "newborn_1_scdf": [
         [
             "Any",

--- a/resources/dicts/patrols/lifegen/df.json
+++ b/resources/dicts/patrols/lifegen/df.json
@@ -16,7 +16,7 @@
         ],
         "patrol_art": "df_default",
         "min_cats": 1,
-        "max_cats": 3,
+        "max_cats": 1,
         "min_max_status": {},
         "weight": 20,
         "intro_text": "You wake up in a forest. Shadowy trees hang overhead, and you feel eyes on you despite not seeing anyone around.",
@@ -564,7 +564,8 @@
         ],
         "tags": [
             "border",
-            "non_lethal"
+            "non_lethal",
+            "fellowtrainee"
         ],
         "patrol_art": "df_friendly",
         "min_cats": 2,
@@ -812,7 +813,8 @@
         ],
         "tags": [
             "border",
-            "convince_rc"
+            "convince_rc",
+            "fellowtrainee"
         ],
         "patrol_art": "df_friendly",
         "min_cats": 2,
@@ -882,7 +884,8 @@
         ],
         "tags": [
             "border",
-            "convince_rc"
+            "convince_rc",
+            "fellowtrainee"
         ],
         "patrol_art": "df_default",
         "min_cats": 2,
@@ -1176,7 +1179,8 @@
         ],
         "tags": [
             "border",
-            "new_cat"
+            "new_cat",
+            "fellowtrainee"
         ],
         "patrol_art": "df_default",
         "min_cats": 2,

--- a/resources/dicts/patrols/lifegen/df.json
+++ b/resources/dicts/patrols/lifegen/df.json
@@ -791,6 +791,12 @@
                 "exp": 20,
                 "weight": 10,
                 "dead_cats": ["r_c"],
+                "murder": [
+                    {
+                        "murderer": ["y_c"],
+                        "victim": ["r_c"]
+                    }
+                ],
                 "history_text": {
                     "reg_death": "m_c was murdered by in the Dark Forest.",
                     "lead_death": "murdered in the Dark Forest"
@@ -998,7 +1004,7 @@
         ]
     },
     {
-        "patrol_id": "life_df_og12",
+        "patrol_id": "life_df_J1",
         "biome": [
             "Any"
         ],
@@ -1086,7 +1092,7 @@
         ]
     }, 
     {
-        "patrol_id": "life_df_og13",
+        "patrol_id": "life_df_J2",
         "biome": [
             "Any"
         ],
@@ -1167,7 +1173,7 @@
         ]
     },
     {
-        "patrol_id": "life_df_og14",
+        "patrol_id": "life_df_J3",
         "biome": [
             "Any"
         ],
@@ -1254,6 +1260,153 @@
                 "exp": 20,
                 "weight": 5,
                 "dead_cats": ["r_c"]
+            }
+        ]
+    },
+    {
+        "patrol_id": "life_df_J4",
+        "biome": [
+            "Any"
+        ],
+        "season": [
+            "Any"
+        ],
+        "types": [
+            "df"
+        ],
+        "tags": [
+            "border",
+            "new_cat",
+            "fellowtrainee"
+        ],
+        "patrol_art": "df_default",
+        "min_cats": 2,
+        "max_cats": 2,
+        "min_max_status": {},
+        "weight": 10,
+        "intro_text": "After managing to sneak away a brutal group training session, you've managed to find one of the only drinkable water sources in the entire Dark Forest. Just as you start to lift your head from the puddle, a cat tackles you from the side, knocking the air from your lungs. r_c pins you to the ground, looking startled to see you but not backing down.",
+        "decline_text": "You freeze in fear and r_c takes pity. They toss you aside and you instantly sprint away. The water can be all theirs.",
+        "chance_of_success": 30,
+        "success_outcomes": [
+            {
+                "text": "Taking advantage of r_c's surprise, you launch them into the water and run. You hear them calling out after you, but you don't dare return.",
+                "exp": 20,
+                "weight": 20
+            },
+            {
+                "text": "When they see who you are, r_c jumps off of you, apologising profusely and stating that they just wanted to defend their watering hole. They decide that you can share it, so long as you don't tell anyone else.",
+                "exp": 20,
+                "weight": 10,
+                "relationships": [
+                    {
+                        "cats_to": ["y_c"],
+                        "cats_from": ["r_c"],
+                        "mutual": false,
+                        "values": ["trust", "comfort"],
+                        "amount": 15
+                    }
+                ]
+            }
+        ],
+        "fail_outcomes": [
+            {
+                "text": "r_c gives you a good scratch before you can wriggle away, and your fresh wound is sore in the morning.",
+                "exp": 0,
+                "weight": 20,
+                "injury": [ 
+                    {
+                        "cats": ["y_c"],
+                        "injuries": ["claw-wound"],
+                        "scars": ["FACE"]
+                    }
+                ],
+                "history_text": {
+                    "scar": "m_c was scarred by a Clanmate in the Dark Forest.",
+                    "reg_death": "m_c was killed by a Clanmate in the Dark Forest.",
+                    "lead_death": "{VERB/m_c/were/was} killed by a Clanmate in the Dark Forest."
+                }
+            },
+            {
+                "text": "The shock is enough to startle you awake, and when you see r_c the next morning, they avoid your gaze completely.",
+                "exp": 0,
+                "weight": 30,
+                "relationships": [
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": true,
+                        "values": ["dislike"],
+                        "amount": 10
+                    }
+                ]
+            }
+        ],
+        "antag_fail_outcomes": [
+            {
+                "text": "You think that fighting back will be easy, but r_c is a fair match. They know this terrain better than you, and they take advantage of your lack of knowledge to leave you with a nasty injury.",
+                "exp": 0,
+                "weight": 20,
+                "injury": [
+                    {
+                        "cats": ["y_c"],
+                        "injuries": ["big_bite_injury"]
+                    }
+                ]
+            },
+            {
+                "text":"You know you should fight back, but you're equally surprised to see them as r_c is to see you. They're able to get over their shock quicker, though, and they quickly shove you into the water. A paw lands on the back of your head, driving your muzzle into the wet sand. You fight and scream, but you can't reach them. It must be by some grace of StarClan that you manage to startle awake just as your vision starts to flicker.",
+                "exp": 0,
+                "weight": 20,
+                "relationships": [
+                    {
+                        "cats_to": ["patrol"],
+                        "cats_from": ["patrol"],
+                        "mutual": true,
+                        "values": ["trust", "platonic_love"],
+                        "amount": -20
+                    }
+                ],
+                "injury": [
+                    {
+                        "cats": ["y_c"],
+                        "injuries": ["water in their lungs"]
+                    }
+                ]
+            }
+        ],
+        "antag_success_outcomes": [
+            {
+                "text": "While r_c is shocked by the sight of you, you shoot a paw towards their throat. Claws sunk into their neck, you yank them to the ground next to you and take off before they have a chance to react.",
+                "exp": 30,
+                "weight": 30,
+                "injury": [
+                    {
+                        "cats": ["r_c"],
+                        "injuries": ["claw-wound"],
+                        "scars": ["THROAT"]
+                    }
+                ],
+                "history_text": {
+                    "scar": "m_c was scarred by a Dark Forest warrior.",
+                    "reg_death": "m_c was killed by a Dark Forest warrior.",
+                    "lead_death": "{VERB/m_c/were/was} killed by a Dark Forest warrior."
+                }
+            },
+            {
+                "text": "Angry that r_c was able to catch you off-guard, and knowing that you can't risk them knowing that you train here, you know there's only one way to take care of the situation. You're stronger than your Clanmate-- you know it. Taking advantage of their surprise upon seeing you, you quickly overpower them and sink your teeth into their throat. When the Clan wakes up tomorrow, no one can explain the gorey scene left in r_c's nest.",
+                "exp": 40,
+                "weight": 10,
+                "dead_cats": ["r_c"],
+                "murder": [
+                    {
+                        "murderer": ["y_c"],
+                        "victim": ["r_c"]
+                    }
+                ],
+                "history_text": {
+                    "reg_death": "m_c was killed in a fight with a Clanmate in the Dark Forest.",
+                    "lead_death": "died in a fight with a Clanmate in the Dark Forest."
+                }
             }
         ]
     }

--- a/resources/dicts/patrols/lifegen/warrior.json
+++ b/resources/dicts/patrols/lifegen/warrior.json
@@ -822,5 +822,43 @@
                 "weight": 20
 			}
 		]
+	},
+	{
+		"patrol_id": "lifegen_shunned_warrior_1",
+        "biome": [
+            "Any"
+        ],
+        "season": [
+            "Any"
+        ],
+        "types": [
+            "hunting"
+        ],
+        "tags": [
+            "border",
+            "shunned"
+        ],
+        "patrol_art": "lg_warrior_default",
+        "min_cats": 1,
+        "max_cats": 1,
+        "min_max_status": {},
+        "weight": 20,
+        "intro_text": "Though you're not allowed out of camp, your paws are itching to hunt. It's late, and most cats are asleep, save for the night guard. You consider trying to sneak past them to finally catch some fresh prey for yourself.",
+        "decline_text": "No, it's far too risky. Not wanting to risk extending your punishment, you go to sleep with an empty stomach.",
+        "chance_of_success": 50,
+        "success_outcomes": [
+		    {
+                "text": "Thankfully, your nest is already at the edge of camp. It's no challenge to slip out, and when you do, you have to stop yourself from yelping with joy at the sight of live prey. The sleeping squirrel doesn't awaken until far too late, and it's the most delicious meal you've had since your punishment began.",
+                "exp": 20,
+                "weight": 20
+            }
+        ],
+        "fail_outcomes": [
+            {
+                "text": "You stand from your nest to attempt to slip out of camp, but the night guard senses the movement and snaps their head towards you. They shoot you a warning glance and you settle back into your nest, not wanting to extend your punishment further.",
+                "exp": 0,
+                "weight": 20
+			}
+		]
 	}
 ]

--- a/resources/dicts/relationship_events/become_mates.json
+++ b/resources/dicts/relationship_events/become_mates.json
@@ -33,9 +33,9 @@
 		"Tails twined together, m_c and r_c announce that love has blossomed between them. They've become mates.",
 		"It's endearing how embarassed m_c is, with {PRONOUN/m_c/object} and r_c briefly becoming the center of attention as new mates.",
 		"No one is going to blame m_c for the pride {PRONOUN/m_c/subject} display in succcessfully asking r_c to become {PRONOUN/m_c/poss} mate. It's a wonderful life event to celebrate, and something to rightfully congratulate the couple on.", 
-        "Truth be told, m_c and r_c, while a tangy spark appears between the two, it wasn't a wildfire; a mutual crush was the best description. However, there was no better honor than to expend and gain respect from their Clan. And so, the two became mates.",
-        "Throughout their days together, it was no stranger that m_c and r_c revealed similar thoughts; who are they, in a romantic sense. Romance is a tricky subject, and it's still is between the two. They've seen Clanmates group together, and, to see the fuss about it, the two agreed to become mates",
-        "Anyone can aid the Clan surplus of kits, but lately it's hard for the constant illness and battles hovering about. To help with the cause, althrough neither hoard any burning romance between the two, m_c and r_c became mates"
+        "Truth be told, while a spark is evident between m_c and r_c, it's no large wildfire-- more like a humble flicker. However, there was no better honour than to expend and gain respect from their Clan. And so, the two have become mates.",
+        "Throughout their days together, m_c and r_c have expressed similar thoughts; who are they, in a romantic sense? Romance is a tricky subject, and neither quite fully understands it. But they've seen their Clanmates pairing up, and, to see what all the fuss is about it, the two have agreed to become mates",
+        "Anyone can aid the Clan surplus of kits, but lately it's hard with the constant illness and battles hovering about. To help with the cause, though there's no burning romance between the two, m_c and r_c have become mates."
 	],
 	"platonic_to_romantic": [
 		"m_c and r_c see each other in a different light and have become mates.",

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -256,7 +256,7 @@
 		"best_stat_modifier": 10,
 		"fail_stat_cat_modifier": -15,
 		"chance_of_romance_patrol": 16,
-		"debug_ensure_patrol_id": "life_df_J4",
+		"debug_ensure_patrol_id": null,
 		"comment": [
 			"the Cruel Season difficulty modifier needs to have a space rather than an underscore,",
 			"due to how it's written in the save files. So don't try to 'fix' it."

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -256,7 +256,7 @@
 		"best_stat_modifier": 10,
 		"fail_stat_cat_modifier": -15,
 		"chance_of_romance_patrol": 16,
-		"debug_ensure_patrol_id": null,
+		"debug_ensure_patrol_id": "life_df_J4",
 		"comment": [
 			"the Cruel Season difficulty modifier needs to have a space rather than an underscore,",
 			"due to how it's written in the save files. So don't try to 'fix' it."

--- a/scripts/cat/history.py
+++ b/scripts/cat/history.py
@@ -680,13 +680,13 @@ class History:
         murder_history = History.get_murders(cat)
         victim_history = History.get_murders(victim)
 
-        cat.revealed += 1
-        if cat.revealed > 0 and cat.shunned < 1:
+        cat.revealed = cat.moons
+        if cat.shunned == 0:
             cat.shunned = 1
             cat.thought = "Is upset that they have been shunned"
 
-            # if random.randint(1,4) == 1:
-            cat.get_injured("guilt")
+            if random.randint(1,4) == 1:
+                cat.get_injured("guilt")
 
             for app in cat.apprentice:
                 fetched_cat = Cat.fetch_cat(app)

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -356,7 +356,7 @@ class Patrol():
             elif clan_hostile:
                 possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_HOSTILE))
 
-        if game.current_screen == 'patrol screen2' or game.current_screen =='patrol screen3' or game.current_screen =='patrol screen4':
+        if game.current_screen == 'patrol screen' or game.current_screen == 'patrol screen2' or game.current_screen =='patrol screen3' or game.current_screen =='patrol screen4':
             final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, current_season,
                                                                             patrol_type)
 
@@ -615,9 +615,10 @@ class Patrol():
 
         # makes sure that it grabs patrols in the correct biomes, season, with the correct number of cats
         for patrol in possible_patrols:
+
             if not self._check_constraints(patrol):
                 continue
-            
+
             # Don't check for repeat patrols if ensure_patrol_id is being used. 
             if not isinstance(game.config["patrol_generation"]["debug_ensure_patrol_id"], str) and \
                     patrol.patrol_id in self.used_patrols:
@@ -649,15 +650,26 @@ class Patrol():
             if current_season not in patrol.season and "Any" not in patrol.season:
                 continue
             if game.current_screen == 'patrol screen':
+
                 if game.clan.your_cat.status == "kitten" and "kit_only" not in patrol.tags:
                     continue
                 elif game.clan.your_cat.status != "kitten" and "kit_only" in patrol.tags:
                     continue
 
-            if game.current_screen == "patrol screen":
+                if game.clan.your_cat.shunned == 0:
+                    if "shunned" in patrol.tags:
+                        continue
+                elif game.clan.your_cat.shunned > 0:
+                    if "shunned" not in patrol.tags:
+                        print('not shunned patrol')
+                        continue
+                    else:
+                        print('shunned patrol')
+
                 if "bloodthirsty_only" in patrol.tags:
                     if Cat.all_cats.get(game.clan.your_cat.mentor).personality.trait != "bloodthirsty":
                         continue
+
             if game.current_screen == 'patrol screen4':
                 if "you_med" in patrol.tags:
                     if game.clan.your_cat.status != 'medicine cat':
@@ -682,17 +694,18 @@ class Patrol():
                     elif 'herb_gathering' not in patrol.types and patrol_type == 'med':
                         continue
 
-            if len(self.patrol_cats) > 1:
-                
-                other_cat = self.patrol_cats[1]
-                
-                if not other_cat.joined_df:
-                    if "fellowtrainee" in patrol.tags:
-                        continue
-                
-                else:
-                    if "fellowtrainee" not in patrol.tags:
-                        continue
+            if "df" in patrol.types:
+                if len(self.patrol_cats) > 1:
+                    
+                    other_cat = self.patrol_cats[1]
+                    
+                    if not other_cat.joined_df:
+                        if "fellowtrainee" in patrol.tags: 
+                            continue
+                    
+                    else:
+                        if "fellowtrainee" not in patrol.tags:
+                            continue
 
 
             # cruel season tag check
@@ -704,7 +717,7 @@ class Patrol():
                 romantic_patrols.append(patrol)
             else:
                 filtered_patrols.append(patrol)
-
+        
         # make sure the hunting patrols are balanced
         if patrol_type == 'hunting':
             filtered_patrols = self.balance_hunting(filtered_patrols)

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -653,6 +653,7 @@ class Patrol():
                     continue
                 elif game.clan.your_cat.status != "kitten" and "kit_only" in patrol.tags:
                     continue
+
             if game.current_screen == "patrol screen":
                 if "bloodthirsty_only" in patrol.tags:
                     if Cat.all_cats.get(game.clan.your_cat.mentor).personality.trait != "bloodthirsty":
@@ -664,6 +665,7 @@ class Patrol():
                 if "df" in patrol.tags:
                     if not game.clan.your_cat.joined_df:
                         continue
+                    
             #  correct button check
             if game.current_screen == 'patrol screen2':
                 if patrol_type == "general":
@@ -679,6 +681,19 @@ class Patrol():
                         continue
                     elif 'herb_gathering' not in patrol.types and patrol_type == 'med':
                         continue
+
+            if len(self.patrol_cats) > 1:
+                
+                other_cat = self.patrol_cats[1]
+                
+                if not other_cat.joined_df:
+                    if "fellowtrainee" in patrol.tags:
+                        continue
+                
+                else:
+                    if "fellowtrainee" not in patrol.tags:
+                        continue
+
 
             # cruel season tag check
             if "cruel_season" in patrol.tags:

--- a/scripts/patrol/patrol_outcome.py
+++ b/scripts/patrol/patrol_outcome.py
@@ -509,9 +509,9 @@ class PatrolOutcome():
             victim_ob = gather_cat_objects(victim, patrol)
             
             # Remove any "None" that might have snuck in
-            if None in cats_from_ob:
+            if None in murderer_ob:
                 murderer_ob.remove(None)
-            if None in cats_to_ob:
+            if None in victim_ob:
                 victim_ob.remove(None)
           
     def _handle_condition_and_scars(self, patrol:'Patrol') -> str:

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -1465,7 +1465,7 @@ class MakeClanScreen(Screens):
             if self.tortiebase:
                 self.elements['tortiebase'] = pygame_gui.elements.UIDropDownMenu(Pelt.tortiebases, str(self.tortiebase), scale(pygame.Rect((column3_x, y_pos[4]), (250, 70))), manager=MANAGER)
             else:
-                self.elements['tortiebase'] = pygame_gui.elements.UIDropDownMenu(Pelt.tortiebases, "single", scale(pygame.Rect((column3_x, y_pos[4]), (250, 70))), manager=MANAGER)
+                self.elements['tortiebase'] = pygame_gui.elements.UIDropDownMenu(Pelt.tortiebases, str(self.tortiebase), scale(pygame.Rect((column3_x, y_pos[4]), (250, 70))), manager=MANAGER)
 
             if self.pattern:
                 self.elements['pattern'] = pygame_gui.elements.UIDropDownMenu(Pelt.tortiepatterns, str(self.pattern), scale(pygame.Rect((column4_x, y_pos[4]), (250, 70))), manager=MANAGER)
@@ -1478,7 +1478,7 @@ class MakeClanScreen(Screens):
             if self.tortiepattern:
                 self.elements['tortiepattern'] = pygame_gui.elements.UIDropDownMenu(pelts_tortie, str(self.tortiepattern), scale(pygame.Rect((column4_x, y_pos[6]), (250, 70))), manager=MANAGER)
             else:
-                self.elements['tortiepattern'] = pygame_gui.elements.UIDropDownMenu(pelts_tortie, "Bengal", scale(pygame.Rect((column4_x, y_pos[6]), (250, 70))), manager=MANAGER)
+                self.elements['tortiepattern'] = pygame_gui.elements.UIDropDownMenu(pelts_tortie, "single", scale(pygame.Rect((column4_x, y_pos[6]), (250, 70))), manager=MANAGER)
 
             if self.pname != "Tortie":
                 self.elements['pattern'].disable()

--- a/scripts/screens/MurderScreen.py
+++ b/scripts/screens/MurderScreen.py
@@ -371,7 +371,7 @@ class MurderScreen(Screens):
         if not accomplice or not accompliced:
             punishment_chance = 1
         if punishment_chance == 1 or punishment_chance == 3:
-            you.revealed = game.clan.age
+            you.revealed = you.moons # so forgiven dialogue can go away later wo me having to make a new parameter
         if punishment_chance == 1:
             if accomplice and not accompliced:
                 a_s = randint(1,2)

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1245,8 +1245,8 @@ class ProfileScreen(Screens):
         else:
             self.exile_return_button.hide()
 
-        if self.the_cat.shunned == 0 and self.the_cat.revealed > 0 and not self.the_cat.outside and not self.the_cat.exiled:
-            print("This cat has been forgiven for murder.")
+        # if self.the_cat.shunned == 0 and self.the_cat.revealed > 0 and not self.the_cat.outside and not self.the_cat.exiled:
+        #     print("This cat has been forgiven for murder.")
 
     def determine_previous_and_next_cat(self):
         """'Determines where the next and previous buttons point too."""

--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1225,12 +1225,16 @@ class ProfileScreen(Screens):
             elif "attended half-moon" in game.switches and game.switches["attended half-moon"]:
                 self.profile_elements["halfmoon"].disable()
 
-        if (self.the_cat.outside) and self.the_cat.ID == game.clan.your_cat.ID and not self.the_cat.dead and self.the_cat.exiled or self.the_cat.status == 'former Clancat':
-            self.exile_return_button.show()
+        if self.the_cat.outside and self.the_cat.ID == game.clan.your_cat.ID and not self.the_cat.dead and (self.the_cat.exiled or self.the_cat.status == 'former Clancat'):
             if game.clan.exile_return:
                 self.exile_return_button.disable()
+            else:
+                self.exile_return_button.show()
         else:
             self.exile_return_button.hide()
+
+        if self.the_cat.shunned == 0 and self.the_cat.revealed > 0 and not self.the_cat.outside and not self.the_cat.exiled:
+            print("This cat has been forgiven for murder.")
 
     def determine_previous_and_next_cat(self):
         """'Determines where the next and previous buttons point too."""

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -481,6 +481,30 @@ class TalkScreen(Screens):
             if "you_sc" in tags and you.df:
                 continue
 
+            murdered_them = False
+            for murder_event in you.history.murder["is_murderer"]:
+                if cat.ID == murder_event.get("victim"):
+                    murdered_them = True
+                    break
+
+            if murdered_them and "murderedthem" not in tags:
+                continue
+
+            if "murderedthem" in tags and not murdered_them:
+                continue
+
+            murdered_you = False
+            for murder_event in cat.history.murder["is_murderer"]:
+                if you.ID == murder_event.get("victim"):
+                    murdered_you = True
+                    break
+
+            if murdered_you and "murderedyou" not in tags:
+                continue
+
+            if "murderedyou" in tags and not murdered_you:
+                continue
+
             if "grief stricken" in cat.illnesses:
                 dead_cat = Cat.all_cats.get(cat.illnesses['grief stricken'].get("grief_cat"))
                 if "grievingyou" in tags:

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -529,28 +529,30 @@ class TalkScreen(Screens):
             
             # FORGIVEN TAGS
 
-            # if you.history:
-            #     if you.history.murder:
-            #         if "is_murderer" in you.history.murder:
-            #             youmurders = len(you.history.murder["is_murderer"])
-            #             if you.moons > you.revealed + 12: # 12 moons after being "forgiven" you can get reg dialogue again
-            #                 if youmurders > 0 and you.shunned == 0 and "you_forgiven" not in tags:
-            #                     continue
-            # if cat.history:
-            #     if cat.history.murder:
-            #         if "is_murderer" in cat.history.murder:
-            #             catmurders = len(cat.history.murder["is_murderer"])
-            #             if cat.moons > cat.revealed + 12:
-            #                 if catmurders > 0 and cat.shunned == 0 and "they_forgiven" not in tags:
-            #                     continue
+            youreforgiven = False
+            theyreforgiven = False
 
-            # if "you_forgiven" in tags and (you.shunned > 0 or youmurders == 0):
-            #     continue
+            if you.moons < you.revealed + 10: # after ten moons, 100% regular dialogue returns
+                if you.history:
+                    if you.history.murder:
+                        if "is_murderer" in you.history.murder:
+                            if len(you.history.murder["is_murderer"]) > 0 and you.shunned == 0 and "you_forgiven" not in tags:
+                                continue
+                            else:
+                                youreforgiven = True
+            if cat.moons < cat.revealed + 10:
+                if cat.history:
+                    if cat.history.murder:
+                        if "is_murderer" in cat.history.murder:
+                            if len(cat.history.murder["is_murderer"]) > 0 and cat.shunned == 0 and "they_forgiven" not in tags:
+                                continue
+                            else:
+                                theyreforgiven = True
+            
+            if "you_forgiven" in tags and (you.shunned > 0 or not youreforgiven):
+                continue
 
-            # if "they_forgiven" in tags and (cat.shunned > 0 or catmurders == 0):
-            #     continue
-
-            if "you_forgiven" in tags or "they_forgiven" in tags:
+            if "they_forgiven" in tags and (cat.shunned > 0 or not theyreforgiven):
                 continue
 
 
@@ -935,7 +937,7 @@ class TalkScreen(Screens):
             game.clan.talks.clear()
 
         weights2 = []
-        weighted_tags = ["you_pregnant", "they_pregnant", "from_mentor", "from_your_parent", "from_adopted_parent", "adopted_parent", "half sibling", "littermate", "siblings_mate", "cousin", "adopted_sibling", "parents_siblings", "from_mentor", "from_your_kit", "from_your_apprentice", "from_mate", "from_parent", "adopted_parent", "from_kit", "sibling", "from_adopted_kit", "they_injured", "they_ill", "you_injured", "you_ill", "you_grieving"]
+        weighted_tags = ["you_pregnant", "they_pregnant", "from_mentor", "from_your_parent", "from_adopted_parent", "adopted_parent", "half sibling", "littermate", "siblings_mate", "cousin", "adopted_sibling", "parents_siblings", "from_mentor", "from_your_kit", "from_your_apprentice", "from_mate", "from_parent", "adopted_parent", "from_kit", "sibling", "from_adopted_kit", "they_injured", "they_ill", "you_injured", "you_ill", "you_grieving", "you_forgiven", "they_forgiven"]
         for item in texts_list.values():
             tags = item["tags"] if "tags" in item else item[0]
             num_fam_mentor_tags = 1

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -482,10 +482,12 @@ class TalkScreen(Screens):
                 continue
 
             murdered_them = False
-            for murder_event in you.history.murder["is_murderer"]:
-                if cat.ID == murder_event.get("victim"):
-                    murdered_them = True
-                    break
+            if you.history:
+                if you.history.murder:
+                    for murder_event in you.history.murder["is_murderer"]:
+                        if cat.ID == murder_event.get("victim"):
+                            murdered_them = True
+                            break
 
             if murdered_them and "murderedthem" not in tags:
                 continue
@@ -494,10 +496,12 @@ class TalkScreen(Screens):
                 continue
 
             murdered_you = False
-            for murder_event in cat.history.murder["is_murderer"]:
-                if you.ID == murder_event.get("victim"):
-                    murdered_you = True
-                    break
+            if cat.history:
+                if cat.history.murder:
+                    for murder_event in cat.history.murder["is_murderer"]:
+                        if you.ID == murder_event.get("victim"):
+                            murdered_you = True
+                            break
 
             if murdered_you and "murderedyou" not in tags:
                 continue
@@ -517,14 +521,38 @@ class TalkScreen(Screens):
             if "grief stricken" in you.illnesses:
                 dead_cat = Cat.all_cats.get(you.illnesses['grief stricken'].get("grief_cat"))
                 if "grievingthem" in tags:
-                    if dead_cat.name == cat.name:
-                        print ('You are grieving the death of this cat.')
-                        
                     if dead_cat.name != cat.name:
                         continue
                 else:
                     if dead_cat.name == cat.name:
                         continue
+            
+            # FORGIVEN TAGS
+
+            # if you.history:
+            #     if you.history.murder:
+            #         if "is_murderer" in you.history.murder:
+            #             youmurders = len(you.history.murder["is_murderer"])
+            #             if you.moons > you.revealed + 12: # 12 moons after being "forgiven" you can get reg dialogue again
+            #                 if youmurders > 0 and you.shunned == 0 and "you_forgiven" not in tags:
+            #                     continue
+            # if cat.history:
+            #     if cat.history.murder:
+            #         if "is_murderer" in cat.history.murder:
+            #             catmurders = len(cat.history.murder["is_murderer"])
+            #             if cat.moons > cat.revealed + 12:
+            #                 if catmurders > 0 and cat.shunned == 0 and "they_forgiven" not in tags:
+            #                     continue
+
+            # if "you_forgiven" in tags and (you.shunned > 0 or youmurders == 0):
+            #     continue
+
+            # if "they_forgiven" in tags and (cat.shunned > 0 or catmurders == 0):
+            #     continue
+
+            if "you_forgiven" in tags or "they_forgiven" in tags:
+                continue
+
 
             roles = ["they_kitten", "they_apprentice", "they_medicine_cat_apprentice", "they_mediator_apprentice", "they_queen's_apprentice", "they_warrior", "they_mediator", "they_medicine_cat", "they_queen", "they_deputy", "they_leader", "they_elder", "they_newborn"]
             if any(r in roles for r in tags):


### PR DESCRIPTION
- r_c now onyl goes on appropriate df patrols depending on their joined_df value
- "murder" patrol block so df clanmate kills r added to history. i kind of fucked up patrol_outcome bc it started working and i didnt wanna fuck w it anymore. if u want to clean it up at some point (or actually code it well so that the murderer doesnt always have to be y_c) pls be my guest
- also murderedthem and murderedyou tags for dialogue + defaults to avoid meow errors (hopefully)
- also forgiven cat dialogue but commented out for later.  just did it so i dont forget later