### PR TITLE
Pronoun Tagged LG Patrols, Meow Errors, DF Backstories

### DIFF
--- a/resources/dicts/backstories.json
+++ b/resources/dicts/backstories.json
@@ -127,10 +127,10 @@
     "dead12": "This cat was killed by Twolegs.",
     "dead13" : "This cat was struck down by StarClan for failing to fulfill a prophecy.",
     "dead14": "This cat was struck down by StarClan for failing to heed an omen.",
+    "dead15": "This cat died peacefully in their sleep.",
     "oldstarclan1": "This cat snuck into StarClan when {PRONOUN/m_c/subject} died, but was discovered and exiled back to the Dark Forest after many years.",
     "oldstarclan2": "This cat was originally from StarClan, but after getting lost in the Dark Forest one day, {PRONOUN/m_c/subject} {VERB/m_c/were/was} unable to find {PRONOUN/m_c/poss} way back. Now, {PRONOUN/m_c/subject} belong to the Place of No Stars, resenting {PRONOUN/m_c/poss} StarClan family who never came to find {PRONOUN/m_c/object}.",
-    "oldstarclan3" : "This cat belonged to StarClan once, but got lost outside of StarClan territory one day and has been bitterly wandering the Dark Forest ever since.",
-    "starclan1": "This cat died peacefully in their sleep."
+    "oldstarclan3" : "This cat belonged to StarClan once, but got lost outside of StarClan territory one day and has been bitterly wandering the Dark Forest ever since."
   },
   "backstory_display": {
     "clan_founder_backstories": "Clan founder",
@@ -162,16 +162,25 @@
       "dead12"
     ],
     "starclan_backstories": [
-      "starclan1"
+      "dead1",
+      "dead3",
+      "dead4",
+      "dead6",
+      "dead8",
+      "dead10",
+      "dead12",
+      "dead15"
     ],
     "df_backstories": [
+      "dead2",
+      "dead5",
       "dead7",
+      "dead8",
       "dead9",
+      "dead11",
+      "dead12",
       "dead13",
-      "dead14",
-      "oldstarclan1",
-      "oldstarclan2",
-      "oldstarclan3"
+      "dead14"
     ],
     "clan_founder_backstories": [
       "clan_founder",

--- a/resources/dicts/events/ceremonies/ceremony-master.json
+++ b/resources/dicts/events/ceremonies/ceremony-master.json
@@ -3136,5 +3136,42 @@
       "all_traits"
     ],
     "Time has taken its toll, and m_c has noticed {PRONOUN/m_c/self} slowing down. {PRONOUN/m_c/subject/CAP} {VERB/m_c/have/has} worked timelessly for many moons, but it is time for {PRONOUN/m_c/object} to retire. "
+  ],
+  "shunned_app1": [
+    [
+      "apprentice",
+      "yes_leader_mentor",
+      "general_parents",
+      "yes_leader",
+      "general_backstory",
+      "all_traits",
+      "shunned"
+    ],
+    "(mentor) has decided to mentor {PRONOUN/m_c/object} personally to keep an eye on them."
+  ],
+  "shunned_app2": [
+    [
+      "apprentice",
+      "yes_mentor",
+      "yes_leader_mentor",
+      "general_parents",
+      "general_leader",
+      "general_backstory",
+      "all_traits",
+      "shunned"
+    ],
+    "m_c has been assigned (mentor) as {PRONOUN/m_c/poss} mentor. Training will begin when-- and if-- {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been forgiven."
+  ],
+  "shunned_app3": [
+    [
+      "apprentice",
+      "no_mentor",
+      "general_parents",
+      "general_leader",
+      "general_backstory",
+      "all_traits",
+      "shunned"
+    ],
+    "m_c wishes {PRONOUN/m_c/subject} could be a real apprentice. For now, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} stuck waiting until {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} forgiven."
   ]
 }

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -2430,5 +2430,49 @@
         [
             "Not the time or the place. Move along."
         ]
+    ],
+    "grievingyou_J1": [
+        [
+            "they_grieving",
+            "grievingyou",
+            "any"
+        ],
+        [
+            "Wh-what?! y_c?!",
+            "I've finally lost my mind.",
+            "But, um... thank you, ghost."
+        ]
+    ],
+    "grievingyou_J2": [
+        [
+            "they_grieving",
+            "grievingyou",
+            "any",
+            "reject"
+        ],
+        [
+            "I must be going insane. y_c is dead... they would never say that..."
+        ]
+    ],
+    "grievingthem_J1": [
+        [
+            "you_grieving",
+            "grievingthem",
+            "any"
+        ],
+        [
+            "I love and miss you too, y_c."
+        ]
+    ],
+    "grievingthem_J2": [
+        [
+            "you_grieving",
+            "grievingthem",
+            "any",
+            "reject"
+        ],
+        [
+            "You're not thinking clearly right now..."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -2122,6 +2122,46 @@
             "Ugh..."
         ]
     ],
+    "flirt_sh_J43": [
+        [
+            "Any",
+            "both_shunned"
+        ],
+        [
+            "Hehe, I don't think that now is really the time..."
+        ]
+    ],
+    "flirt_sh_J44": [
+        [
+            "Any",
+            "both_shunned",
+            "reject"
+        ],
+        [
+            "Not the time, y_c."
+        ]
+    ],
+    "flirt_sh_J45": [
+        [
+            "Any",
+            "both_shunned",
+            "they_grieving",
+            "reject"
+        ],
+        [
+            "Um... no."
+        ]
+    ],
+    "flirt_sh_J46": [
+        [
+            "Any",
+            "both_shunned",
+            "they_grieving"
+        ],
+        [
+            "Maybe later, y_c."
+        ]
+    ],
     "flirting_shunned_SQ4": [
         [
             "Any",
@@ -2461,7 +2501,7 @@
             "any"
         ],
         [
-            "I love and miss you too, y_c."
+            "I love and missed you too, y_c."
         ]
     ],
     "grievingthem_J2": [
@@ -2473,6 +2513,135 @@
         ],
         [
             "You're not thinking clearly right now..."
+        ]
+    ],
+    "bothgrieving_flirt_J1": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "any"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J2": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J3": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J4": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "both_shunned",
+            "any"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J5": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "any",
+            "reject"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J6": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "they_shunned",
+            "any",
+            "reject"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J7": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any",
+            "reject"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J8": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "both_shunned",
+            "any",
+            "reject"
+        ],
+        [
+            "I don't know what's going on anymore."
+        ]
+    ],
+    "bothgrieving_flirt_J9": [
+        [
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any",
+            "reject"
+        ],
+        [
+            "Absolutely not, y_c. Neither of us are in any state for this. Especially you."
+        ]
+    ],
+    "bothgrieving_flirt_J10": [
+        [
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "Come back later, y_c. Thank you, but I can't do this right now."
         ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -12309,7 +12309,7 @@
             "only_you_deaf"
         ],
         [
-            "... ... .."
+            "... ... ..."
         ]
     ],
     "bothshunned_sh_J12": [
@@ -12319,7 +12319,7 @@
             "only_you_deaf"
         ],
         [
-            "... ... .."
+            "... ... ..."
         ]
     ],
     "bothshunned_sh_J13": [
@@ -12330,7 +12330,7 @@
             "only_they_deaf"
         ],
         [
-            "... ... .."
+            "... ... ..."
         ]
     ],
     "general_sh_J14": [
@@ -14744,7 +14744,7 @@
             "Is it true that some StarClan cats are powerful enough to make the moon cover the sun?"
         ]
     ],
-    "shunned_sc": [
+    "shunned_sc1": [
         [
             "you_sc",
             "any",
@@ -14756,7 +14756,32 @@
             "Ah, you wouldn't understand..."
         ]
     ],
-    "shunned_df": [
+    "shunned_sc2": [
+        [
+            "you_sc",
+            "any",
+            "they_shunned"
+        ],
+        [
+            "I'm still gonna be allowed to join you guys when I die, right?",
+            "... Right?!"
+        ]
+    ],
+    "shunned_sc3": [
+        [
+            "you_sc",
+            "any",
+            "they_shunned"
+        ],
+        [
+            "Oh! y_c.",
+            "Here to judge me? Tell me how I've failed? Or are you here to take me up to StarClan with you?",
+            "My stomach has been kind of upset today...",
+            "[You tell t_c that, no, they're not dying, and you're just here to visit.]",
+            "Oh. Okay. Fine."
+        ]
+    ],
+    "shunned_df1": [
         [
             "you_df",
             "any",
@@ -14766,6 +14791,33 @@
             "I've made some mistakes, I admit it.",
             "But do I deserve this? I don't!",
             "You would know, wouldn't you, y_c?"
+        ]
+    ],
+    "shunned_df2": [
+        [
+            "you_df",
+            "any",
+            "they_shunned"
+        ],
+        [
+            "Oh, hello, y_c.",
+            "You here to bring me to the Dark Forest with you?",
+            "My head has been a bit sore today...",
+            "[You tell t_c that, no, they're not dying, and you're just here to visit.]",
+            "Oh! Phew, thank StarClan.",
+            "I mean-- sorry. That's not offensive, is it?"
+        ]
+    ],
+    "shunned_df3": [
+        [
+            "you_df",
+            "any",
+            "they_shunned"
+        ],
+        [
+            "Am I gonna join you guys when I die?",
+            "You don't know? I thought dead cats were supposed to know everything.",
+            "Hmph. Fine. I guess we'll see, huh?"
         ]
     ],
     "they_shunned_grieving": [
@@ -14786,7 +14838,9 @@
             "you_sc"
         ],
         [
-            "No one deserves what I'm being put through."
+            "Are you punishing me, StarClan cat? Is that why..?",
+            "Well, it's working. I've never felt so awful.",
+            "Happy?"
         ]
     ],
     "they_shunned_grieving3": [
@@ -14797,7 +14851,9 @@
             "you_df"
         ],
         [
-            "No one deserves what I'm being put through."
+            "Got room in the Dark Forest for one more?",
+            "[t_c isn't thinking straight, in their grief. No sane cat would ask to join the Dark Forest.]",
+            "No? Oh, come on. Please? It can't be worse than here."
         ]
     ],
     "grieving_neruotic": [
@@ -14875,57 +14931,56 @@
         [
             "murderedthem",
             "any",
-            "they_sc",
+            "they_dead",
             "you_shunned"
         ],
         [
-            "I hope they exile you.",
-            "I'd say I hope they kill you, but I don't want you up here with me."
+            "You're getting what you deserve, you know."
         ]
     ],
     "murderedthem_J4": [
         [
             "murderedthem",
             "any",
-            "they_df",
+            "they_dead",
             "you_shunned"
         ],
         [
             "I hope they exile you.",
-            "I'd say I hope they kill you, but I don't want you up here with me."
+            "I'd say I hope they kill you, but I don't want here with me."
         ]
     ],
     "murderedthem_J5": [
         [
             "murderedthem",
             "any",
-            "they_sc",
+            "they_dead",
             "you_shunned",
             "you_grieving"
         ],
         [
-            "I hope they exile you.",
-            "I'd say I hope they kill you, but I don't want you up here with me."
+            "Oh? Has someone close to you died?",
+            "Only a truly evil cat would cause such a thing.",
+            "I hope you feel this way every day for the rest of your life after what you did to me."
         ]
     ],
     "murderedthem_J6": [
         [
             "murderedthem",
             "any",
-            "they_df",
+            "they_dead",
             "you_shunned",
             "you_grieving"
         ],
         [
-            "I hope they exile you.",
-            "I'd say I hope they kill you, but I don't want you up here with me."
+            "You don't deserve to ever recover, after what you did to me."
         ]
     ],
     "murderedthem_J7": [
         [
             "murderedthem",
             "any",
-            "they_sc",
+            "they_dead",
             "you_forgiven"
         ],
         [

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -1397,5 +1397,39 @@
             "Did you do it for me? Did you think I wanted this? Or was it for your own sick desires?!",
             "Whatever, I don't care. Don't even look at me. StarClan forbid I ever sink to the level where I love you again."
         ]
+    ],
+    "grievingyouinsult_J1": [
+        [
+            "they_grieving",
+            "grievingyou",
+            "any",
+            "insult"
+        ],
+        [
+            "I know the real y_c would never say that.",
+            "I miss you so much I'm hallucinating you... Why are my hallucinations so mean?"
+        ]
+    ],
+    "grievingtheminsult_J1": [
+        [
+            "you_grieving",
+            "grievingthem",
+            "any",
+            "insult"
+        ],
+        [
+            "It's really me, y_c. You're not insulting a hallucination."
+        ]
+    ],
+    "grievingthemalive_J1": [
+        [
+            "you_grieving",
+            "grievingthem",
+            "any"
+        ],
+        [
+            "Hi, y_c!",
+            "I missed you too. I'll stay a bit longer, this time, I promise."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -1431,5 +1431,277 @@
             "Hi, y_c!",
             "I missed you too. I'll stay a bit longer, this time, I promise."
         ]
+    ],
+    "shunned_insult_J1": [
+        [
+            "insult",
+            "they_shunned",
+            "they_grieving",
+            "any"
+        ],
+        [
+            "[t_c just stares at you blankly.]"
+        ]
+    ],
+    "shunned_insult_J2": [
+        [
+            "insult",
+            "both_shunned",
+            "they_grieving",
+            "any"
+        ],
+        [
+            "What do you have to gain from being so mean?"
+        ]
+    ],
+    "shunned_insult_J3": [
+        [
+            "insult",
+            "both_shunned",
+            "they_grieving",
+            "you_grieving",
+            "any"
+        ],
+        [
+            "I know you don't mean that."
+        ]
+    ],
+    "shunned_insult_J4": [
+        [
+            "insult",
+            "both_shunned",
+            "you_grieving",
+            "grievingthem",
+            "any"
+        ],
+        [
+            "You must be confused."
+        ]
+    ],
+    "shunned_insult_J5": [
+        [
+            "insult",
+            "both_shunned",
+            "they_grieving",
+            "grievingyou",
+            "any"
+        ],
+        [
+            "I know you don't mean that."
+        ]
+    ],
+    "shunned_insult_J6": [
+        [
+            "insult",
+            "both_shunned",
+            "you_grieving",
+            "they_grieving",
+            "grievingthem",
+            "any"
+        ],
+        [
+            "You must be confused."
+        ]
+    ],
+    "shunned_insult_J7": [
+        [
+            "insult",
+            "both_shunned",
+            "they_grieving",
+            "you_grieving",
+            "grievingyou",
+            "any"
+        ],
+        [
+            "I know you don't mean that."
+        ]
+    ],
+    "bothgrieving_J1": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "any"
+        ],
+        [
+            "[You and t_c have been stuck together all day in a never-ending hug.]",
+            "I missed you, y_c.",
+            "[You know. They've told you a dozen times already.]",
+            "[You missed them, too, you tell them for the thirteenth time.]"
+        ]
+    ],
+    "bothgrieving_J2": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "[You and t_c have been stuck together all day in a never-ending hug.]",
+            "I missed you, y_c.",
+            "[You know. They've told you a dozen times already.]",
+            "[You missed them, too, you tell them for the thirteenth time.]"
+        ]
+    ],
+    "bothgrieving_J3": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "[You and t_c have been stuck together all day in a never-ending hug.]",
+            "I missed you, y_c.",
+            "[You know. They've told you a dozen times already.]",
+            "[You missed them, too, you tell them for the thirteenth time.]"
+        ]
+    ],
+    "bothgrieving_J4": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "both_shunned",
+            "any"
+        ],
+        [
+            "[You and t_c have been stuck together all day in a never-ending hug.]",
+            "I missed you, y_c.",
+            "[You know. They've told you a dozen times already.]",
+            "[You missed them, too, you tell them for the thirteenth time.]"
+        ]
+    ],
+    "bothgrieving_insult_J1": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "any"
+        ],
+        [
+            "What? y_c? Why would you say that?"
+        ]
+    ],
+    "bothgrieving_insult_J2": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "What? y_c? Why would you say that?"
+        ]
+    ],
+    "bothgrieving_insult_J3": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "What? y_c? Why would you say that?"
+        ]
+    ],
+    "bothgrieving_insult_J4": [
+        [
+            "grievingyou",
+            "grievingthem",
+            "they_grieving",
+            "you_grieving",
+            "both_shunned",
+            "any"
+        ],
+        [
+            "What? y_c? Why would you say that?"
+        ]
+    ],
+    "deadtoshunned_J1": [
+        [
+            "they_shunned",
+            "they_grieving",
+            "grievingyou",
+            "you_dead",
+            "any"
+        ],
+        [
+            "[t_c is sound asleep. You'd better not wake them.]"
+        ]
+    ],
+    "deadtoshunned_J2": [
+        [
+            "they_shunned",
+            "they_grieving",
+            "you_dead",
+            "any"
+        ],
+        [
+            "[t_c is sound asleep. You'd better not wake them.]"
+        ]
+    ],
+    "deadtoshunned_J3": [
+        [
+            "you_shunned",
+            "you_grieving",
+            "they_dead",
+            "grievingthem",
+            "any"
+        ],
+        [
+            "You're a complicated cat, y_c."
+        ]
+    ],
+    "deadtoshunned_J4": [
+        [
+            "they_shunned",
+            "they_grieving",
+            "you_dead",
+            "grievingyou",
+            "any"
+        ],
+        [
+            "I miss you a lot, y_c.",
+            "Everything in my life is going wrong. How did I miss everything up this badly?",
+            "If you were still here, I might be able to return to normal, but... without you...",
+            "I don't know. Nothing makes sense anymore.",
+            "What do I do?"
+        ]
+    ],
+    "bothgrieving_J5": [
+        [
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any",
+            "insult"
+        ],
+        [
+            "[t_c just stares into space, not hearing you.]"
+        ]
+    ],
+    "bothgrieving_J6": [
+        [
+            "they_grieving",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "You're evil, y_c."
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -2896,7 +2896,7 @@
             "newborn"
         ],
         [
-            "No one deserves what I'm being put through."
+            "[t_c tucks their nose under their paws, ignoring you as you toddle up to them.]"
         ]
     ],
     "they_shunned_grieving2": [
@@ -2908,7 +2908,7 @@
             "newborn"
         ],
         [
-            "No one deserves what I'm being put through."
+            "You have it easy, little one."
         ]
     ],
     "they_shunned_grieving3": [
@@ -2920,7 +2920,9 @@
             "newborn"
         ],
         [
-            "No one deserves what I'm being put through."
+            "Oh, you poor thing.",
+            "Neither of us deserves what we're going through right now.",
+            "I hope you find StarClan one day, little kit."
         ]
     ],
     "they_shunned_grieving4": [
@@ -4166,6 +4168,35 @@
         [
             "you_dead",
             "they_shunned",
+            "any"
+        ],
+        [
+            "Do you get bored being dead?",
+            "Wait, you're so young... Do you know that you're..?",
+            "Ah, never mind. You're looking very nice today, y_c.",
+            "[What are they talking about?]"
+        ]
+    ],
+    "kittentoshunned_J4": [
+        [
+            "you_dead",
+            "they_shunned",
+            "newborn",
+            "any"
+        ],
+        [
+            "Do you get bored being dead?",
+            "Wait, you're so young... Do you know that you're..?",
+            "Ah, never mind. You're looking very nice today, y_c.",
+            "[What are they talking about?]"
+        ]
+    ],
+    "kittentoshunned_J5": [
+        [
+            "you_dead",
+            "they_shunned",
+            "they_grieving",
+            "newborn",
             "any"
         ],
         [

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -2923,6 +2923,18 @@
             "No one deserves what I'm being put through."
         ]
     ],
+    "they_shunned_grieving4": [
+        [
+            "any",
+            "both_shunned",
+            "they_grieving",
+            "you_grieving",
+            "insult"
+        ],
+        [
+            "That's mean, y_c. You're allowed to be upset, but please dont take it out on me."
+        ]
+    ],
     "sc_newborn": [
         [
             "newborn",
@@ -4125,6 +4137,42 @@
             "y_c??",
             "Oh, right... you're... a ghost?",
             "[t_c sniffles.]"
+        ]
+    ],
+    "kittentoshunned_J1": [
+        [
+            "you_dead",
+            "they_grieving",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "[t_c doesn't notice you at all.]"
+        ]
+    ],
+    "kittentoshunned_J2": [
+        [
+            "you_dead",
+            "they_grieving",
+            "grievingyou",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "[The sight of you makes t_c tear up. Maybe you'll visit later.]"
+        ]
+    ],
+    "kittentoshunned_J3": [
+        [
+            "you_dead",
+            "they_shunned",
+            "any"
+        ],
+        [
+            "Do you get bored being dead?",
+            "Wait, you're so young... Do you know that you're..?",
+            "Ah, never mind. You're looking very nice today, y_c.",
+            "[What are they talking about?]"
         ]
     ]
 }

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -5305,5 +5305,77 @@
         [
             "Hey, there, little guy."
         ]
+    ],
+    "deadkit_J1": [
+        [
+            "they_dead",
+            "you_grieving",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "You look really sad, y_c. What happened?",
+            "No, I do wanna know, I really do!",
+            "O-oh... well, you don't have to tell me, I guess...",
+            "I hope you feel better soon."
+        ]
+    ],
+    "deadkit_J2": [
+        [
+            "they_dead",
+            "you_grieving",
+            "any"
+        ],
+        [
+            "I'm sorry they had to come to StarClan so soon.",
+            "But you can talk to us, can't you? Go find them, it'll be like they never left!",
+            "[You don't know how to explain that it's not the same.]"
+        ]
+    ],
+    "deadkit_J3": [
+        [
+            "they_dead",
+            "you_shunned",
+            "any"
+        ],
+        [
+            "The other StarClan cats told me you might not be allowed here when you die. Did you do something bad?",
+            "I'll tell them they should reconsider. I'm super smart with words, they'll have to listen to me, just watch!",
+            "[t_c runs off.]"
+        ]
+    ],
+    "deadkit_J4": [
+        [
+            "you_dead",
+            "any",
+            "they_shunned",
+            "newborn"
+        ],
+        [
+            "Why are you here?"
+        ]
+    ],
+    "deadkit_J5": [
+        [
+            "you_dead",
+            "any",
+            "they_shunned",
+            "they_grieving",
+            "newborn"
+        ],
+        [
+            "Why are you here?"
+        ]
+    ],
+    "deadkit_J6": [
+        [
+            "you_dead",
+            "any",
+            "they_grieving",
+            "newborn"
+        ],
+        [
+            "Why are you here?"
+        ]
     ]
 }

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -1774,5 +1774,82 @@
         [
             "Mrrp?"
         ]
+    ],
+    "deadnewborns_J2": [
+        [
+            "they_shunned",
+            "they_grieving",
+            "any",
+            "you_dead"
+        ],
+        [
+            "Um... hi, little fellow.",
+            "You probably shouldn't be here."
+        ]
+    ],
+    "deadnewborns_J3": [
+        [
+            "they_shunned",
+            "any",
+            "you_dead"
+        ],
+        [
+            "Um... hi, little fellow.",
+            "You probably shouldn't be here."
+        ]
+    ],
+    "deadnewborns_J4": [
+        [
+            "they_grieving",
+            "any",
+            "you_dead"
+        ],
+        [
+            "Um... hi, little fellow.",
+            "You probably shouldn't be here."
+        ]
+    ],
+    "deadnewborns_J5": [
+        [
+            "they_shunned",
+            "they_grieving",
+            "grievingyou",
+            "you_dead",
+            "any"
+        ],
+        [
+            "Oh, y_c... It's torture to see you everywhere."
+        ]
+    ],
+    "deadnewborns_J6": [
+        [
+            "you_shunned",
+            "you_grieving",
+            "any",
+            "they_dead"
+        ],
+        [
+            "Mew? Mew? ... Mew?"
+        ]
+    ],
+    "deadnewborns_J7": [
+        [
+            "you_grieving",
+            "any",
+            "they_dead"
+        ],
+        [
+            "Mew? Mew? ... Mew?"
+        ]
+    ],
+    "deadnewborns_J8": [
+        [
+            "you_shunned",
+            "any",
+            "they_dead"
+        ],
+        [
+            "Mew? Mew? ... Mew?"
+        ]
     ]
 }

--- a/resources/dicts/patrols/lifegen/date.json
+++ b/resources/dicts/patrols/lifegen/date.json
@@ -16,12 +16,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You see the first snowflakes of leaf-bare falling down. You can't help but notice r_c looking up at the sky with wonder. Maybe you should play in the snow with them?",
+        "intro_text": "You see the first snowflakes of leaf-bare falling down. You can't help but notice r_c looking up at the sky with wonder. Maybe you should play in the snow with {PRONOUN/r_c/object}?",
         "decline_text": "You decide against it. You don't want to freeze to death, after all.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "They agree to it! You walk through the forest, tails entwined, when suddenly you feel a shower of ice hit your face! You look to r_c bewilderedly, realizing that they flicked snow at you! You have a snow battle that ends with the both of you dissolving into giggles.",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/agree/agrees} to it! You walk through the forest, tails entwined, when suddenly you feel a shower of ice hit your face! You look to r_c bewilderedly, realizing that {PRONOUN/r_c/subject} flicked snow at you! You have a snow battle that ends with the both of you dissolving into giggles.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -37,7 +37,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You walk up to r_c and invite them to play, but they think you're joking. You laugh along with them, but you can't help but feel a sore disappointment.",
+                "text": "You walk up to r_c and invite {PRONOUN/r_c/object} to play, but {PRONOUN/r_c/subject} {VERB/r_c/think/thinks} you're joking. You laugh along with {PRONOUN/r_c/object}, but you can't help but feel a sore disappointment.",
                 "exp": 0,
                 "weight": 20
             }
@@ -114,12 +114,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You hear around the den about a shooting star event happening that evening. You consider asking r_c about whether or not they wish to watch it with you.",
-        "decline_text": "No... what if they think you're weird for wanting to watch your dead ancestors fall out the sky?!",
+        "intro_text": "You hear around the den about a shooting star event happening that evening. You consider asking r_c about whether or not {PRONOUN/r_c/subject} {VERB/r_c/wish/wishes} to watch it with you.",
+        "decline_text": "No... what if {PRONOUN/r_c/subject} {VERB/r_c/think/thinks} you're weird for wanting to watch your dead ancestors fall out the sky?!",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You find them while they're getting some fresh kill and ask if they'd like to attend with you. They seem to be happy that you asked! You have a wonderful evening watching the stars with them.",
+                "text": "You find {PRONOUN/r_c/object} while {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} getting some fresh kill and ask if {PRONOUN/r_c/subject}'d like to attend with you. {PRONOUN/r_c/subject/CAP} {VERB/r_c/seem/seems} to be happy that you asked! You have a wonderful evening watching the stars with {PRONOUN/r_c/object}.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -135,7 +135,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "They're talking to another cat, when you find them. They gently inform you that they're watching it with someone else. You slink off, embarrassed. You feel so bad that you don't even go to see it.",
+                "text": "{PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} talking to another cat, when you find {PRONOUN/r_c/object}. {PRONOUN/r_c/subject/CAP} gently inform you that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} watching it with someone else. You slink off, embarrassed. You feel so bad that you don't even go to see it.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -216,7 +216,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You gently lean into r_c, resting your head on their shoulder. You can hear a purr emanating from their throat, and they slowly lay their chin on the top of your head as you watch the sunrise together.",
+                "text": "You gently lean into r_c, resting your head on {PRONOUN/r_c/poss} shoulder. You can hear a purr emanating from {PRONOUN/r_c/poss} throat, and {PRONOUN/r_c/subject} slowly {VERB/r_c/rest/rests} {PRONOUN/r_c/poss} chin on the top of your head as you watch the sunrise together.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -232,7 +232,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You slowly inch closer to r_c and lean your head on their shoulder, but they glare you down and scoot away uncomfortably. Ouch, that was awkward...",
+                "text": "You slowly inch closer to r_c and lean your head on {PRONOUN/r_c/poss} shoulder, but {PRONOUN/r_c/subject} glare you down and scoot away uncomfortably. Ouch, that was awkward...",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -269,7 +269,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "They agree! Phew. The two of you have a wonderful day, jumping around in the waves and engaging in small water fights, and you feel like your connection has strengthened.",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/agree/agrees}! Phew. The two of you have a wonderful day, jumping around in the waves and engaging in small water fights, and you feel like your connection has strengthened.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -285,7 +285,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "They agree, and you walk out to the seabank together. When you've stepped out in the water, r_c looks at you questionably, not seeming to understand why you think this is fun. You attempt to show them as you joyfully jump around, but a sharp wave hits r_c and they hiss loudly, walking back with a soaked pelt. Maybe this wasn't the best idea after all..",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/agree/agrees}, and you walk out to the seabank together. When you've stepped out in the water, r_c looks at you questionably, not seeming to understand why you think this is fun. You attempt to show {PRONOUN/r_c/object} as you joyfully jump around, but a sharp wave hits r_c and {PRONOUN/r_c/subject} hiss loudly, walking back with a soaked pelt. Maybe this wasn't the best idea after all..",
                 "exp": 0,
                 "weight": 20
             }
@@ -308,12 +308,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "As you wander out by the cliffs with r_c you notice a few pretty flowers sticking out of a pile of snow. Perhaps you should pick some for them?",
+        "intro_text": "As you wander out by the cliffs with r_c you notice a few pretty flowers sticking out of a pile of snow. Perhaps you should pick some for {PRONOUN/r_c/object}?",
         "decline_text": "You don't want to risk getting your paws all cold and wet - and worse, what if r_c doesn't want them?",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You tell r_c to stop for a moment as you carefully lift the flowers. r_c looks confused, but lights up in a smile as you drop the flowers in front of them. They decide to wear the flowers on their pelt, and you feel all warm and fuzzy as you continue the patrol.",
+                "text": "You tell r_c to stop for a moment as you carefully lift the flowers. r_c looks confused, but lights up in a smile as you drop the flowers in front of {PRONOUN/r_c/object}. {PRONOUN/r_c/subject/CAP} decide to wear the flowers on {PRONOUN/r_c/poss} pelt, and you feel all warm and fuzzy as you continue the patrol.",
                 "exp": 0,
                 "weight": 20,
                 "accessory": [
@@ -368,7 +368,7 @@
         "relationship_constraint": ["not_mates"],
         "success_outcomes": [
             {
-                "text": "r_c happily agrees saying they'd love to go out with you. The two of you wander through c_n's territory and you find yourself staring at them for extended periods of time. How have you never noticed their beauty?",
+                "text": "r_c happily agrees saying {PRONOUN/r_c/subject}'d love to go out with you. The two of you wander through c_n's territory and you find yourself staring at {PRONOUN/r_c/object} for extended periods of time. How have you never noticed {PRONOUN/r_c/poss} beauty?",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -407,12 +407,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You leave camp on a moon high patrol with r_c. It's getting close to leafbare, and the air is starting to get frigid. You think about pressing up against r_c and wrapping your tail around them. Just because it's cold!",
+        "intro_text": "You leave camp on a moon high patrol with r_c. It's getting close to leafbare, and the air is starting to get frigid. You think about pressing up against r_c and wrapping your tail around {PRONOUN/r_c/object}. Just because it's cold!",
         "decline_text": "Nope. You don't do that. That would be weird. You choose to respect r_c's boundaries.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You lean against them and they let out a surprised purr, and thank you. They joked that they were getting cold, but now they're at the perfect temperature thanks to you.",
+                "text": "You lean against {PRONOUN/r_c/object} and {PRONOUN/r_c/subject} {VERB/r_c/let/lets} out a surprised purr, and thank you. {PRONOUN/r_c/subject/CAP} joke that {PRONOUN/r_c/subject} {VERB/r_c/were/was} getting cold, but now {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} at the perfect temperature thanks to you.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -428,7 +428,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "They hiss a warning at you, asking what you're doing and you retreat immediately. The rest of the patrol is painfully awkward.",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/hiss/hisses} a warning at you, asking what you're doing and you retreat immediately. The rest of the patrol is painfully awkward.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -460,12 +460,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "As you pad around the land, you spot r_c sitting at your favorite pond. They are looking longingly into the sky. You debate approaching them.",
+        "intro_text": "As you pad around the land, you spot r_c sitting at your favorite pond. {PRONOUN/r_c/subject/CAP} {VERB/r_c/are/is} looking longingly into the sky. You debate approaching {PRONOUN/r_c/object}.",
         "decline_text": "Nevermind, you have an important patrol ahead. You decide to move onwards.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "With a large sigh, you follow the path leading over to them. You both smile at each other and eventually you both entwine your tails together.",
+                "text": "With a large sigh, you follow the path leading over to {PRONOUN/r_c/object}. You both smile at each other and eventually you both entwine your tails together.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -481,7 +481,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You trot up to r_c and sit down. They nervously shuffles away and politely declines. You walk away to continue your patrol, embarrassed.",
+                "text": "You trot up to r_c and sit down. {PRONOUN/r_c/subject/CAP} nervously shuffles away and politely {VERB/r_c/decline/declines}. You walk away to continue your patrol, embarrassed.",
                 "exp": 0,
                 "weight": 20
             }
@@ -504,12 +504,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "It's a foggy morning, but a sound on the breeze catches your attention. Immediately, r_c pops into your brain. They would want to see this.",
-        "decline_text": "It's too early in the morning, r_c enjoys their rest.",
+        "intro_text": "It's a foggy morning, but a sound on the breeze catches your attention. Immediately, r_c pops into your brain. {PRONOUN/r_c/subject/CAP} would want to see this.",
+        "decline_text": "It's too early in the morning, r_c enjoys {PRONOUN/r_c/poss} rest.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c seems surprised to see you when they open their eyes, but eventually get to their feet. As the morning sun turns orange with the dawn, the two of you watch in silence. The local hawk's nest has hatched, and every now and again, you catch a glimpse of a chick.",
+                "text": "r_c seems surprised to see you when {PRONOUN/r_c/subject} {VERB/r_c/open/opens} {PRONOUN/r_c/poss} eyes, but eventually {VERB/r_c/get/gets} to {PRONOUN/r_c/poss} feet. As the morning sun turns orange with the dawn, the two of you watch in silence. The local hawk's nest has hatched, and every now and again, you catch a glimpse of a chick.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -525,7 +525,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c doesn't even stir from their nest, rather swats you away.",
+                "text": "r_c doesn't even stir from {PRONOUN/r_c/poss} nest, rather swats you away.",
                 "exp": 0,
                 "weight": 20
             }
@@ -548,12 +548,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You're out fishing with r_c when you notice them staring into the dark water with a sad expression on their face.",
-        "decline_text": "You decide it's not your place to be nosy. You respect r_c's boundaries, after all. If it was important, they'd tell you, right?",
+        "intro_text": "You're out fishing with r_c when you notice {PRONOUN/r_c/object} staring into the dark water with a sad expression on {PRONOUN/r_c/poss} face.",
+        "decline_text": "You decide it's not your place to be nosy. You respect r_c's boundaries, after all. If it was important, {PRONOUN/r_c/subject}'d tell you, right?",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You carefully ask r_c what's on their mind. They tell you about how they've been feeling worthless lately, and the dark, cloudy weather hasn't been helping. They splash the water in frustration. You give them a soft smile and reassure them of their worth, splashing some water back at them. The moment of sadness turns into a fun water fight.",
+                "text": "You carefully ask r_c what's on {PRONOUN/r_c/poss} mind. {PRONOUN/r_c/subject/CAP} {VERB/r_c/tell/tells} you about how {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been feeling worthless lately, and the dark, cloudy weather hasn't been helping. {PRONOUN/r_c/subject/CAP} {VERB/r_c/splash/splashes} the water in frustration. You give {PRONOUN/r_c/object} a soft smile and reassure {PRONOUN/r_c/object} of {PRONOUN/r_c/poss} worth, splashing some water back at {PRONOUN/r_c/object}. The moment of sadness turns into a fun water fight.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -569,7 +569,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You ask r_c what's on their mind, but they shrug you off and dismiss their worries, instead telling you to focus on the task at paw. You both go back to fishing in an awkward atmosphere. Does r_c not trust you enough? Are you annoying them...?",
+                "text": "You ask r_c what's on {PRONOUN/r_c/poss} mind, but {PRONOUN/r_c/subject} {VERB/r_c/shrug/shrugs} you off and dismiss {PRONOUN/r_c/poss} worries, instead telling you to focus on the task at paw. You both go back to fishing in an awkward atmosphere. Does r_c not trust you enough? Are you annoying {PRONOUN/r_c/object}...?",
                 "exp": 0,
                 "weight": 20
             }
@@ -595,12 +595,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You need herbs for the medicine den, and decide to bring r_c with you. You appreciate them coming with you, the extra paws are a massive help! You notice how their fur sparkles beautifully with dew, looking almost like silverpelt had come alive on them. You consider telling them so.",
-        "decline_text": "Nope. They're here on business. They're just helping you get herbs. Don't get any weird ideas.",
+        "intro_text": "You need herbs for the medicine den, and decide to bring r_c with you. You appreciate {PRONOUN/r_c/object} coming with you, as the extra paws are a massive help! You notice how {PRONOUN/r_c/poss} fur sparkles beautifully with dew, looking almost like Silverpelt had come alive on {PRONOUN/r_c/object}. You consider telling {PRONOUN/r_c/object} so.",
+        "decline_text": "Nope. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} here on business. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} just helping you get herbs. Don't get any weird ideas.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c purres in amusement, telling you that you look very pretty yourself. You go the rest of your day holding your tail high in pride.",
+                "text": "r_c purrs in amusement, telling you that you look very pretty yourself. You go the rest of your day holding your tail high in pride.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -616,7 +616,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c sighs and tells you to focus on finding herbs so they can get back to camp. You're genuinely upset by this. Do they not like spending time with you? It was only a joke, you keep telling both them and yourself to save yourself the deadly claws to your pride.",
+                "text": "r_c sighs and tells you to focus on finding herbs so they can get back to camp. You're genuinely upset by this. {VERB/r_c/Do/Does} {PRONOUN/r_c/subject} not like spending time with you? It was only a joke, you keep telling both {PRONOUN/r_c/object} and yourself to save yourself the deadly claws to your pride.",
                 "exp": 0,
                 "weight": 20
             }
@@ -639,13 +639,13 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You decide to take r_c to a lovely view in the early hours of dawn. The cliffs provide a stunning vision of the sun rising. After a while of staring, your tail brushes against r_c's and you wonder if now would be the time to ask them if they feel anything for you...",
-        "decline_text": "No! No way in StarClan! You're too awkward for that! So you just sit in silence with them.",
+        "intro_text": "You decide to take r_c to a lovely view in the early hours of dawn. The cliffs provide a stunning vision of the sun rising. After a while of staring, your tail brushes against r_c's and you wonder if now would be the time to ask {PRONOUN/r_c/poss} if {PRONOUN/r_c/subject} {VERB/r_c/feel/feels} anything for you...",
+        "decline_text": "No! No way in StarClan! You're too awkward for that! So you just sit in silence with {PRONOUN/r_c/object}.",
         "chance_of_success": 50,
         "relationship_constraint": ["not_mates"],
         "success_outcomes": [
             {
-                "text": "You nervously ask r_c and they look away, blushing a bit. They purr and tell you to just focus on the sky though you can't help but notice them glancing at you affectionately every now and then.",
+                "text": "You nervously ask r_c and {PRONOUN/r_c/subject} look away, blushing a bit. {PRONOUN/r_c/subject/CAP} purr and tell you to just focus on the sky, though you can't help but notice {PRONOUN/r_c/object} glancing at you affectionately every now and then.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -661,7 +661,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c stares at you with an awkward expression. You got the wrong idea. They just wanted to enjoy the sunrise. But now, they can't. r_c walks away in a huff, leaving you upset...",
+                "text": "r_c stares at you with an awkward expression. You got the wrong idea. {PRONOUN/r_c/subject/CAP} just wanted to enjoy the sunrise. But now, {PRONOUN/r_c/subject} can't. r_c walks away in a huff, leaving you upset...",
                 "exp": 0,
                 "weight": 20
             }
@@ -684,12 +684,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You decide to take r_c on a walk around the borders on a warm night and spot a twoleg kit playing in the dirt. r_c gives you a look and a curious purr.",
+        "intro_text": "You decide to take r_c on a walk around the borders on a warm night and spot a Twoleg kit playing in the dirt. r_c gives you a look and a curious purr.",
         "decline_text": "You shake your head and r_c seems almost disappointed, but keeps up.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You can't help but see what they are thinking and agree, watching as r_c creeps through some tall grass before leaping out and scaring the twoleg kit. On the way back, you and r_c laugh about what happened and have a great new inside joke.",
+                "text": "You can't help but see what {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} thinking and agree, watching as r_c creeps through some tall grass before leaping out and scaring the Twoleg kit. On the way back to camp, you and r_c laugh about what happened and have a great new inside joke.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -705,7 +705,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c creeps through the grass and instead gets spotted by a second twoleg kit. r_c gets scooped up and you quickly jump in and scare the twoleg kits off. r_c sits beside you, panicked, as you try to comfort them. Instead they just get distant and ask to finish the patrol.",
+                "text": "r_c creeps through the grass and instead gets spotted by a second Twoleg kit. r_c gets scooped up and you quickly jump in and scare the Twoleg kits off. r_c sits beside you, panicked, as you try to comfort {PRONOUN/r_c/object}. Instead {PRONOUN/r_c/subject} just {VERB/r_c/get/gets} distant and asks to finish the patrol.",
                 "exp": 0,
                 "weight": 20
             }
@@ -728,8 +728,8 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c encounter a huge, open field in the territory. Whilst there's many out in the plains, none had quite as many flowers as this one. Your gaze catches on r_c's before you begin to run, hoping they'll follow.",
-        "decline_text": "You slow to a stop, feeling stupid for even trying to do that. You stutter out an excuse to r_c before heading back over to them, your ears burning with embarrassment.",
+        "intro_text": "You and r_c encounter a huge, open field in the territory. Whilst there's many out in the plains, none had quite as many flowers as this one. Your gaze catches on r_c's before you begin to run, hoping {PRONOUN/r_c/subject}'ll follow.",
+        "decline_text": "You slow to a stop, feeling stupid for even trying to do that. You stutter out an excuse to r_c before heading back over to {PRONOUN/r_c/object}, your ears burning with embarrassment.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
@@ -759,7 +759,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c just stands there as you begin to run and you slow to a stop, meowing confusedly at them. They glare at you, telling you to get back to work as they turn to continue on the intended patrol path... you can't help but shrink from how awkward that was.",
+                "text": "r_c just stands there as you begin to run and you slow to a stop, meowing confusedly at {PRONOUN/r_c/object}. {PRONOUN/r_c/subject/CAP} glare at you, telling you to get back to work as {PRONOUN/r_c/subject} {VERB/r_c/turn/turns} to continue on the intended patrol path... you can't help but shrink from how awkward that was.",
                 "exp": 0,
                 "weight": 20
             }
@@ -782,12 +782,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c take a walk through the forest at night, the soft croaking of frogs seeming to ring out to the beat of your pawsteps. You spot a long field of grass, and remember something someone taught you when you were just a kit. You turn to r_c, wanting to ask them something.",
+        "intro_text": "You and r_c take a walk through the forest at night, the soft croaking of frogs seeming to ring out to the beat of your pawsteps. You spot a long field of grass, and remember something someone taught you when you were just a kit. You turn to r_c, wanting to ask {PRONOUN/r_c/object} something.",
         "decline_text": "You can't muster up the courage to ask, and turn back to the patrol, your gaze flitting back to the field longingly.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You ask if they'd like to run through the field. Confused, they agree, and gasp once they do. Fireflies flew out of the long grass, swirling around the two of you like a spiral of lights. However, the only light that catches your eye is the joy in theirs.",
+                "text": "You ask if {PRONOUN/r_c/subject}'d like to run through the field. Confused, {PRONOUN/r_c/subject} {VERB/r_c/agree/agrees}, and {VERB/r_c/gasp/gasps} once {PRONOUN/r_c/subject} {VERB/r_c/do/does}. Fireflies fly out of the long grass, swirling around the two of you like a spiral of lights. However, the only light that catches your eye is the joy in {PRONOUN/r_c/inposs}.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -803,7 +803,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You ask if they'd like to run through the field. Confused, they refuse, and tell you to get back to patrolling.",
+                "text": "You ask if {PRONOUN/r_c/subject}'d like to run through the field. Confused, {PRONOUN/r_c/subject} refuse, and tell you to get back to patrolling.",
                 "exp": 0,
                 "weight": 20
             }
@@ -826,12 +826,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c pad along the coast, the glittering waves of the cool water lapping at your paws. r_c was looking especially tense lately, and you wished to see their warm smile appear on their face once again. Looking at the rising and falling waves, you notice coquina clams being pulled out of the sand and quickly burying themselves back under, and you get an idea.",
-        "decline_text": "But due to the anxiety in your heart that you would accidentally make r_c more tense then they already are, you say nothing and the two of you continue the patrol in silence.",
+        "intro_text": "You and r_c pad along the coast, the glittering waves of the cool water lapping at your paws. r_c has been looking especially tense lately, and you wish to see {PRONOUN/r_c/poss} warm smile appear on {PRONOUN/r_c/poss} face once again. Looking at the rising and falling waves, you notice coquina clams being pulled out of the sand and quickly burying themselves back under, and you get an idea.",
+        "decline_text": "But due to the anxiety in your heart that you would accidentally make r_c more tense then {PRONOUN/r_c/subject} already {VERB/r_c/are/is}, you say nothing and the two of you continue the patrol in silence.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "Quickly grabbing r_c's attention with a playful mew, you dash towards the small oncoming wave and gracefully leap into it. r_c yelps in shock and wades slowly into the water to find you and make sure you're okay, until your soaked head pops out of the water with a colorful coquina clam in your jaws. r_c is confused for a moment until you start imitating a silly voice, doing your best to open and close the clam in sync with your words. They burst out in laughter, their warm smile back on their beautifully lit face from the dusk.",
+                "text": "Quickly grabbing r_c's attention with a playful mew, you dash towards the small oncoming wave and gracefully leap into it. r_c yelps in shock and wades slowly into the water to find you and make sure you're okay, until your soaked head pops out of the water with a colorful coquina clam in your jaws. r_c is confused for a moment until you start imitating a silly voice, doing your best to open and close the clam in sync with your words. {PRONOUN/r_c/subject/CAP} {VERB/r_c/burst/bursts} out in laughter, {PRONOUN/r_c/poss} warm smile back on {PRONOUN/r_c/poss} beautifully lit face from the dusk.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -847,7 +847,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You dash into the water and jump into an oncoming wave, but you underestimated how strong the wave was going to be, and you were immediately pushed back onto the shore on your back. You hoped that your failed attempt at swimming would make r_c giggle even a little bit, but watching you suddenly leap into the water and be aggressively thrown by a wave only heightened r_c's stress levels, and they now walked ahead of you after heavily reprimanding you on the dangers of the ocean. That clearly didn't make them feel better...",
+                "text": "You dash into the water and jump into an oncoming wave, but you underestimated how strong the wave was going to be, and you're immediately pushed back onto the shore on your back. You hope that your failed attempt at swimming might make r_c giggle even a little bit, but watching you suddenly leap into the water and be aggressively thrown by a wave only heightened r_c's stress levels, and {PRONOUN/r_c/subject} now {VERB/r_c/walk/walks} ahead of you after heavily reprimanding you on the dangers of the ocean. That clearly didn't make {PRONOUN/r_c/object} feel better...",
                 "exp": 0,
                 "weight": 20
             }
@@ -875,7 +875,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You gently brush your tail across r_c's shoulder blade, and they thank you with a purr that's a little too warm for the simplicity of the favor.",
+                "text": "You gently brush your tail across r_c's shoulder blade, and {PRONOUN/r_c/subject} {VERB/r_c/thank/thanks} you with a purr that's a little too warm for the simplicity of the favor.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -914,12 +914,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You were on a hunting patrol with r_c, and after catching mouthfuls of prey, you and r_c decided to take a break. You've noticed how pretty the maple leaves look, and wanted to give some to them. Was it a good choice, though?",
-        "decline_text": "You decided not to, and finish the break after a short while to resume hunting.",
+        "intro_text": "You're on a hunting patrol with r_c, and after catching mouthfuls of prey, you and r_c decide to take a break. You've noticed how pretty the maple leaves look, and wanted to give some to {PRONOUN/r_c/object}. Is it a good choice, though?",
+        "decline_text": "You decide not to, and finish the break after a short while to resume hunting.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You stand up and collect the prettiest of maple leaves, and after gathering a good load of them, you step over and show r_c the leaves. They look joyous and gracefully receive the maple leaves from your paw, putting them on their ear.",
+                "text": "You stand up and collect the prettiest of maple leaves, and after gathering a good load of them, you step over and show r_c the leaves. {PRONOUN/r_c/subject/CAP} {VERB/r_c/look/looks} joyous and gracefully {VERB/r_c/recieve/recieves} the maple leaves from your paw, putting them on {PRONOUN/r_c/poss} ear.",
                 "exp": 0,
                 "weight": 20,
                 "accessory": [
@@ -945,7 +945,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "They see you looking around for the leaves and ask what you're doing. You are unsure of what to reply, so you just say you were wandering around. They don't ask you anything anymore, and you give up, soon resuming the patrol.",
+                "text": "{PRONOUN/r_c/subject/CAP} see you looking around for the leaves and ask what you're doing. You are unsure of what to reply, so you just say you were wandering around. {PRONOUN/r_c/subject/CAP} {VERB/r_c/doesn't/don't} ask you anything anymore, and you give up, soon resuming the patrol.",
                 "exp": 0,
                 "weight": 20
             }
@@ -968,12 +968,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You were told about the blue supermoon, and decided it would be a good opportunity to ask r_c out. You pad up to them, but hesitate. What if it doesn't go as planned?",
+        "intro_text": "You were told about the blue supermoon, and decided it would be a good opportunity to ask r_c out. You pad up to {PRONOUN/r_c/object}, but hesitate. What if it doesn't go as planned?",
         "decline_text": "You can't gather enough courage for this, so you stop and turned away. Guess tonight you'll be enjoying it by yourself.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "They turn back, looking at you- and you successfully ask them without stuttering if they want to go see the blue supermoon tonight with you. They happily agree, and when the time comes, you and them sit on top of a tall tree, gazing at the bright, massive, slightly blue-colored moon and the countless sparkly stars together. You feel extremely happy to hear r_c's soft purrs and see their face being lit up.",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/turn/turns} back, looking at you- and you successfully ask {PRONOUN/r_c/object}-- without stuttering-- if {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to go see the blue supermoon tonight with you. {PRONOUN/r_c/subject/CAP} happily {VERB/r_c/agree/agrees}, and when the time comes, you and {PRONOUN/r_c/object} sit on top of a tall tree, gazing at the bright, massive, slightly blue-colored moon and the countless sparkly stars together. You feel extremely happy to hear r_c's soft purrs and see {PRONOUN/r_c/object} face being lit up.",
                 "exp": 20,
                 "weight": 20,
                 "relationships": [
@@ -989,7 +989,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "They politely decline, saying that they have to go on a night patrol, and you weren't selected with them. Seems like tonight you two will be watching the moon from different parts of the territory... or it'll only be r_c  watching.",
+                "text": "{PRONOUN/r_c/subject/CAP} politely {VERB/r_c/decline/declines}, saying that {PRONOUN/r_c/subject} {VERB/r_c/have/has} to go on a night patrol, and you weren't selected with {PRONOUN/r_c/object}. Seems like tonight you two will be watching the moon from different parts of the territory... or it'll only be r_c watching.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1015,12 +1015,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c go out in the Dark Forest, away from the spirits and trainees. r_c - who you've been practicing with and admiring - enthusiastically offers to teach you some of their forbidden moves. Should you practice with them?",
+        "intro_text": "You and r_c go out in the Dark Forest, away from the spirits and trainees. r_c - who you've been practicing with and admiring - enthusiastically offers to teach you some of {PRONOUN/r_c/poss} forbidden moves. Should you practice with {PRONOUN/r_c/poss}?",
         "decline_text": "You feel as if this is a bit too risky. You nervously decline r_c's offer.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You and r_c practice these forbidden moves together. You feel more confident and strong. Later, you and r_c later take a break in the muck, heavily breathing, lightly scratched, but your love and cooperation with r_c slowly growing.",
+                "text": "You and r_c practice these forbidden moves together. You feel more confident and strong. Later, you and r_c later take a break in the muck, heavily breathing, lightly scratched, but your love and cooperation with {PRONOUN/r_c/object} slowly growing.",
                 "exp": 20,
                 "weight": 20,
                 "relationships": [
@@ -1062,12 +1062,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "One of your trainees, r_c, who is also your clanmate, is being taunted and mistreated by a Dark Forest spirit. You feel like stepping up, but you might be injured.",
+        "intro_text": "One of your trainees, r_c, who is also your Clanmate, is being taunted and mistreated by a Dark Forest spirit. You feel like stepping up, but you might be injured.",
         "decline_text": "You don't feel like risking it, so you let r_c be.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You decide to step up, and you approach the spirit who had been berating r_c. They angrily hiss at you and leap on you, and you give them a good fight before making them flee. r_c thanks you, and they help lick your minor wounds clean, but you soon notice yourself leaning on them, tails twining.",
+                "text": "You decide to step up, and you approach the spirit who had been berating r_c. They angrily hiss at you and leap on you, and you give them a good fight before making them flee. r_c thanks you, and {PRONOUN/r_c/subject} {VERB/r_c/help/helps} lick your minor wounds clean, but you soon notice yourself leaning on {PRONOUN/r_c/object}, tails twining.",
                 "exp": 15,
                 "weight": 20,
                 "relationships": [
@@ -1083,7 +1083,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "As you step up, the spirit angrily hisses at you, but you give them a good fight before they flee. You are minorly injured, but r_c doesn't seem to notice this, and they stroll off through the muck without a care about checking on you or thanking you!",
+                "text": "As you step up, the spirit angrily hisses at you, but you give them a good fight before they flee. You are minorly injured, but r_c doesn't seem to notice this, and {PRONOUN/r_c/subject} {VERB/r_c/stroll/strolls} off through the muck without a care about checking on you or thanking you!",
                 "exp": 0,
                 "weight": 20
             }
@@ -1109,12 +1109,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "A Dark Forest cat whispers threats into your ear and taunts you. An unfamiliar Dark Forest clanmate sees you and decides to help, chasing the spirit away. You feel your heart beating full of affection, wanting to say something.",
-        "decline_text": "You decide to walk away, hastily, dragging your tail through the muck. Maybe you weren't meant for them.",
+        "intro_text": "A Dark Forest cat whispers threats into your ear and taunts you. An unfamiliar Dark Forest Clanmate sees you and decides to help, chasing the spirit away. You feel your heart beating full of affection, wanting to say something.",
+        "decline_text": "You decide to walk away, hastily, dragging your tail through the muck. Maybe you weren't meant for {PRONOUN/r_c/object}.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "You respond to the cat a simple thanks, and the cat introduces themself as r_c, who you instantly recognize from your Clan. You two talk for a bit, though you feel as if you are being watched behind your back by the residents of the Dark Forest.",
+                "text": "You respond to the cat a simple thanks, and the cat introduces {PRONOUN/r_c/self} as r_c, who you instantly recognize from your Clan. You two talk for a bit, though you feel as if you are being watched behind your back by the residents of the Dark Forest.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1130,7 +1130,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You awkwardly stutter a thanks to the cat, who you soon recognize to be r_c, but after that, they quickly walk through the muck, away from your sight. Your ears feel hot from embarrassment.",
+                "text": "You awkwardly stutter a thanks to the cat, who you soon recognize to be r_c, but after that, {PRONOUN/r_c/subject} quickly {VERB/r_c/walk/walks} through the muck, away from your sight. Your ears feel hot from embarrassment.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1153,12 +1153,13 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c end up on a patrol together. As you walk together through your clan's territory, the smell of budding plants fills your nostrils and your attention is drawn to r_c. Did they always look so nice? You can't seem to look away, their luxurious fur, the way they walk..",
+        "intro_text": "You and r_c end up on a patrol together. As you walk together through your Clan's territory, the smell of budding plants fills your nostrils and your attention is drawn to r_c. Did {PRONOUN/r_c/subject} always look so nice? You can't seem to look away, {PRONOUN/r_c/poss} luxurious fur, the way {PRONOUN/r_c/subject} {VERB/r_c/walk/walks}..",
         "decline_text": "You shake off the feeling. There are more important things to do than to swoon at a stupid crush.",
         "chance_of_success": 50,
+        "relationship_constraint": ["not_mates"],
         "success_outcomes": [
             {
-                "text": "As you stare over at them, they slowly swivel their head to see you gawking, and chuckle lightly before giving you a warm look. Your heart flutters!",
+                "text": "As you stare over at {PRONOUN/r_c/poss}, {PRONOUN/r_c/subject} slowly {VERB/r_c/swivel/swivels} {PRONOUN/r_c/poss} head to see you gawking, and {VERB/r_c/chuckle/chuckles} lightly before giving you a warm look. Your heart flutters!",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1197,7 +1198,7 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You are assigned one of the more tedious chores around camp. As you're preparing to start, an idea pops into your mind; You could ask r_c if they would want to help out! It would make the chore easier, and you'd get to spend time together!",
+        "intro_text": "You are assigned one of the more tedious chores around camp. As you're preparing to start, an idea pops into your mind; You could ask r_c if {PRONOUN/r_c/subject} would want to help out! It would make the chore easier, and you'd get to spend time together!",
         "decline_text": "You decide not to bother r_c, and instead dive into the chore on your own.",
         "chance_of_success": 50,
         "success_outcomes": [
@@ -1218,7 +1219,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "r_c gives an apologetic look; wouldn't it be better for one cat to do it? Then they wouldn't be in the way... You mutter in agreement, and hurry away. How embarrassing!",
+                "text": "r_c gives an apologetic look; wouldn't it be better for one cat to do it? Then {PRONOUN/r_c/subject} wouldn't be in the way... You mutter in agreement, and hurry away. How embarrassing!",
                 "exp": 0,
                 "weight": 20
             }
@@ -1241,12 +1242,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You've wanted to get closer to r_c for a while now, but you're not quite sure how to do it. An idea strikes you as you consider asking r_c if they'd want to accompany you on a morning stroll out of camp.",
-        "decline_text": "You try to muster up the courage to approach them, but you can't quite seem to catch them at the right time. Your struggle goes on for so long that it's no longer early morning, and you quietly resign yourself to a lonely stroll by yourself for the following days.",
+        "intro_text": "You've wanted to get closer to r_c for a while now, but you're not quite sure how to do it. An idea strikes you as you consider asking r_c if {PRONOUN/r_c/subject}'d want to accompany you on a morning stroll out of camp.",
+        "decline_text": "You try to muster up the courage to approach {PRONOUN/r_c/object}, but you can't quite seem to catch {PRONOUN/r_c/object} at the right time. Your struggle goes on for so long that it's no longer early morning, and you quietly resign yourself to a lonely stroll by yourself for the following days.",
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "r_c agrees to walk with you out of camp, and you have to keep yourself from jumping in joy. In the soft morning light of early sunrise, you quietly admire their side profile to yourself, awed by how their fur looks under the golden lighting.",
+                "text": "r_c agrees to walk with you out of camp, and you have to keep yourself from jumping in joy. In the soft morning light of early sunrise, you quietly admire {PRONOUN/r_c/poss} side profile to yourself, awed by how {PRONOUN/r_c/poss} fur looks under the golden lighting.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1262,7 +1263,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You gather your courage and ask, but you know you've failed as soon as r_c averts their eyes and shuffles their paws awkwardly. They try to let you down gently, but the rejection stings sharply in your chest as you watch them walk away.",
+                "text": "You gather your courage and ask, but you know you've failed as soon as r_c averts {PRONOUN/r_c/poss} eyes and shuffles {PRONOUN/r_c/poss} paws awkwardly. {PRONOUN/r_c/subject/CAP} {VERB/r_c/try/tries} to let you down gently, but the rejection stings sharply in your chest as you watch {PRONOUN/r_c/object} walk away.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1285,13 +1286,13 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You and r_c are assigned in a patrol together, knowing that this is your chance to express your feelings towards them.",
+        "intro_text": "You and r_c are assigned in a patrol together, knowing that this is your chance to express your feelings towards {PRONOUN/r_c/object}.",
         "decline_text": "You decide to focus on your task instead.",
         "chance_of_success": 45,
         "relationship_constraint": ["not_mates"],
         "success_outcomes": [
             {
-                "text": "As r_c and you gather moss, you sheepishly express your love towards them, and they quickly turn their head towards you, and giggles a little, telling you how they have always known how you felt about them, but your shocked expression is full of joy and love. r_c and you manage to gather moss while talking and making jokes together, and when you return to camp, a new aura emerges from r_c.",
+                "text": "As r_c and you gather moss, you sheepishly express your love towards {PRONOUN/r_c/object}, and {PRONOUN/r_c/subject} quickly {VERB/r_c/turn/turns} {PRONOUN/r_c/poss} head towards you and {VERB/r_c/giggle/giggles} a little, telling you how {PRONOUN/r_c/subject} {VERB/r_c/have/has} always known how you felt about {PRONOUN/r_c/object}, but your shocked expression is full of joy and love. r_c and you manage to gather moss while talking and making jokes together, and when you return to camp, a new aura emerges from {PRONOUN/r_c/object}.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1307,7 +1308,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You stutter a lot while trying to express your love towards r_c, but they awkwardly turn their head to look at you, cringing. With their mouth full of moss, r_c doesn't talk to you after that patrol, and quickly continues their duties without interacting with you afterwards.",
+                "text": "You stutter a lot while trying to express your love towards r_c, but {PRONOUN/r_c/subject} awkwardly {VERB/r_c/turn/turns} {PRONOUN/r_c/poss} head to look at you, cringing. With {PRONOUN/r_c/poss} mouth full of moss, r_c doesn't talk to you after that patrol, and quickly continues their duties without interacting with you afterwards.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1426,12 +1427,12 @@
         "max_cats": 3,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You, r_c and o_c1 are strolling along the riverbank. Suddenly, a stone catches your eye. The colour reminds you of o_c1's eyes, and you consider showing it to them.",
+        "intro_text": "You, r_c and o_c1 are strolling along the riverbank. Suddenly, a stone catches your eye. The colour reminds you of o_c1's eyes, and you consider showing it to {PRONOUN/o_c1/object}.",
         "decline_text": "You leave the stone and keep walking.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "When you pick up the rock to show to o_c1, both they and r_c are delighted, agreeing that it looks just like o_c1's eyes. r_c rushes to the water to find a rock to match yours, and soon, all three of you are searching for your perfect match. You each keep someone else's matching rock with you when you head back to camp, and you sleep a little better that night with it by your nest.",
+                "text": "When you pick up the rock to show to o_c1, both {PRONOUN/o_c1/subject} and r_c are delighted, agreeing that it looks just like o_c1's eyes. r_c rushes to the water to find a rock to match yours, and soon, all three of you are searching for your perfect match. You each keep someone else's matching rock with you when you head back to camp, and you sleep a little better that night with it by your nest.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1447,7 +1448,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You call out for r_c and o_c1 one to stop walking, but as you pick up the rock to show them, you lose your grasp on it and it falls into the river, quickly sinking out of sight. r_c and o_c1 giggle at your misfortune, and you laugh along, but you're still disappointed to lose such a cute gift.",
+                "text": "You call out for r_c and o_c1 to stop walking, but as you pick up the rock to show them, you lose your grasp on it and it falls into the river, quickly sinking out of sight. r_c and o_c1 giggle at your misfortune, and you laugh along, but you're still disappointed to lose such a cute gift.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1499,7 +1500,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You approach r_c first, but they tell you they'd rather stay alone today. o_c1 says the same, and you can't help but feel self conscious about the back-to-back rejection.",
+                "text": "You approach r_c first, but {PRONOUN/r_c/subject} {VERB/r_c/tell/tells} you {PRONOUN/r_c/subject}'d rather stay alone today. o_c1 says the same, and you can't help but feel self conscious about the back-to-back rejection.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1524,12 +1525,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You want to spend some time with r_c, but you don't know how they'll react to you asking them out, given what you've done.",
-        "decline_text": "You decide against it, knowing that their rejection is likely inevitable.",
+        "intro_text": "You want to spend some time with r_c, but you don't know how {PRONOUN/r_c/subject}'ll react to you asking {PRONOUN/r_c/object} out, given what you've done.",
+        "decline_text": "You decide against it, knowing that {PRONOUN/r_c/poss} rejection is likely inevitable.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "When you shyly ask r_c if they'd like to spend some time with you, to your surprise, they say yes! While you're not allowed to leave camp, you two lay in the sun together, tails entwined, ignoring the stares your Clanmates give you.",
+                "text": "When you shyly ask r_c if {PRONOUN/r_c/subject}'d like to spend some time with you, to your surprise, {PRONOUN/r_c/subject} {VERB/r_c/say/says} yes! While you're not allowed to leave camp, you two lay in the sun together, tails entwined, ignoring the stares your Clanmates give you.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1545,7 +1546,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You approach r_c to ask them out, but before you can even finish speaking, they react with a 'no' so loud that a few Clanmates turn to look. You quickly retreat, returning to your nest and tryign to get the humiliation out of your mind.",
+                "text": "You approach r_c to ask {PRONOUN/r_c/object} out, but before you can even finish speaking, {PRONOUN/r_c/subject} {VERB/r_c/react/reacts} with a 'no' so loud that a few Clanmates turn to look. You quickly retreat, returning to your nest and trying to get the humiliation out of your mind.",
                 "exp": 0,
                 "weight": 20
             }
@@ -1570,7 +1571,7 @@
         "max_cats": 3,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You see r_c and o_c1 lingering by the camp entrance, seemingly preparing to head out. You'd love to join them, but you don't know if they'd be as open to that as they once were, given what you've done.",
+        "intro_text": "You see r_c and o_c1 lingering by the camp entrance, seemingly preparing to head out. You'd love to join them, but you don't know if they'd be as open to that as they once would be, given what you've done.",
         "decline_text": "You decide against it, knowing that their rejection is likely inevitable.",
         "chance_of_success": 30,
         "success_outcomes": [

--- a/resources/dicts/patrols/lifegen/date.json
+++ b/resources/dicts/patrols/lifegen/date.json
@@ -973,7 +973,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/turn/turns} back, looking at you- and you successfully ask {PRONOUN/r_c/object}-- without stuttering-- if {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to go see the blue supermoon tonight with you. {PRONOUN/r_c/subject/CAP} happily {VERB/r_c/agree/agrees}, and when the time comes, you and {PRONOUN/r_c/object} sit on top of a tall tree, gazing at the bright, massive, slightly blue-colored moon and the countless sparkly stars together. You feel extremely happy to hear r_c's soft purrs and see {PRONOUN/r_c/object} face being lit up.",
+                "text": "{PRONOUN/r_c/subject/CAP} {VERB/r_c/turn/turns} back, looking at you- and you successfully ask {PRONOUN/r_c/object}-- without stuttering-- if {PRONOUN/r_c/subject} {VERB/r_c/want/wants} to go see the blue supermoon tonight with you. {PRONOUN/r_c/subject/CAP} happily {VERB/r_c/agree/agrees}, and when the time comes, you and {PRONOUN/r_c/subject} sit on top of a tall tree, gazing at the bright, massive, slightly blue-colored moon and the countless sparkly stars together. You feel extremely happy to hear r_c's soft purrs and see {PRONOUN/r_c/object} face being lit up.",
                 "exp": 20,
                 "weight": 20,
                 "relationships": [

--- a/resources/dicts/patrols/lifegen/date.json
+++ b/resources/dicts/patrols/lifegen/date.json
@@ -1427,12 +1427,12 @@
         "max_cats": 3,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You, r_c and o_c1 are strolling along the riverbank. Suddenly, a stone catches your eye. The colour reminds you of o_c1's eyes, and you consider showing it to {PRONOUN/o_c1/object}.",
+        "intro_text": "You, r_c and o_c1 are strolling along the riverbank. Suddenly, a stone catches your eye. The colour reminds you of o_c1's eyes, and you consider showing it to the two.",
         "decline_text": "You leave the stone and keep walking.",
         "chance_of_success": 60,
         "success_outcomes": [
             {
-                "text": "When you pick up the rock to show to o_c1, both {PRONOUN/o_c1/subject} and r_c are delighted, agreeing that it looks just like o_c1's eyes. r_c rushes to the water to find a rock to match yours, and soon, all three of you are searching for your perfect match. You each keep someone else's matching rock with you when you head back to camp, and you sleep a little better that night with it by your nest.",
+                "text": "When you pick up the rock to show to o_c1, both cats are delighted, agreeing that it looks just like o_c1's eyes. r_c rushes to the water to find a rock to match yours, and soon, all three of you are searching for your perfect match. You each keep someone else's matching rock with you when you head back to camp, and you sleep a little better that night with it by your nest.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [

--- a/resources/dicts/patrols/lifegen/df.json
+++ b/resources/dicts/patrols/lifegen/df.json
@@ -572,7 +572,7 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "Soon after you fall asleep, you wake up in the Dark Forest. r_c bounds out of the gloom, asking if you would like to train with them.",
+        "intro_text": "Soon after you fall asleep, you wake up in the Dark Forest. r_c bounds out of the gloom, asking if you would like to train with {PRONOUN/r_c/object}.",
         "decline_text": "You politely decline and wander off to train on your own.",
         "chance_of_success": 60,
         "success_outcomes": [
@@ -659,7 +659,7 @@
                 ]
             },
             {
-                "text": "You make good progress on some advanced battle moves, but r_c is looking worse for wear. Their mentor snarls at them that they should work as hard as you. Jealousy glints in r_c's eyes as they face you in daylight the next morning.",
+                "text": "You make good progress on some advanced battle moves, but r_c is looking worse for wear. {PRONOUN/r_c/poss/CAP} mentor snarls at {PRONOUN/r_c/object} that {PRONOUN/r_c/subject} should work as hard as you. Jealousy glints in r_c's eyes as {PRONOUN/r_c/subject} {VERB/r_c/face/faces} you in daylight the next morning.",
                 "exp": 10,
                 "weight": 20,
                 "relationships": [
@@ -694,12 +694,12 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "As you go for a stroll around the Dark Forest, just enjoying the gloomy forest before training begins, you stumble upon a confused r_c. They look up at you, panicked, as they ask where they are.",
-        "decline_text": "Meh. Not your business. You walk away, leaving them startled, confused and sputtering out your name.",
+        "intro_text": "As you go for a stroll around the Dark Forest, just enjoying the gloomy forest before training begins, you stumble upon a confused r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/look/looks} up at you, panicked, as {PRONOUN/r_c/subject} {VERB/r_c/ask/asks} where {PRONOUN/r_c/subject} {VERB/r_c/are/is}.",
+        "decline_text": "Meh. Not your business. You walk away, leaving {PRONOUN/r_c/object} startled, confused and sputtering out your name.",
         "chance_of_success": 90,
         "success_outcomes": [
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area, if they'd like to join you. r_c agrees hesitantly, following your lead.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area, if {PRONOUN/r_c/subject}'d like to join you. r_c agrees hesitantly, following your lead.",
                 "exp": 10,
                 "weight": 20,
                 "relationships": [
@@ -720,7 +720,7 @@
                 ]
             },
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area if they'd like to join you. r_c trusts you, so they eagerly follow your lead.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area if {PRONOUN/r_c/subject}'d like to join you. r_c trusts you, so {PRONOUN/r_c/subject} eagerly {VERB/r_c/follow/follows} your lead.",
                 "exp": 25,
                 "weight": 20,
                 "stat_trait":["cunning", "sincere", "confident","responsible", "loving","loyal", "charismatic", "trusting", "playful", "compassionate","thoughtful"],
@@ -742,7 +742,7 @@
                 ]
             },
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area, if they'd like to join you. r_c hesitates before shaking their head in refusal. Their loss, you suppose. You let them find their own way out as you proceed to the training grounds.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area, if {PRONOUN/r_c/subject}'d like to join you. r_c hesitates before shaking {PRONOUN/r_c/poss} head in refusal. {PRONOUN/r_c/poss/CAP} loss, you suppose. You let {PRONOUN/r_c/object} find {PRONOUN/r_c/poss} own way out as you proceed to the training grounds.",
                 "exp": 10,
                 "weight": 20,
                 "relationships": [
@@ -758,7 +758,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area, if they wish to become stronger. Their eyes are wide with horror as they scream out a loud 'no'. r_c calls you a traitor, swinging their claws at you though missing as you gracefully dodge their attack. Sobbing, they run away, deeper into the forest as you can only watch with pity. Your Dark Forest mentor will have a field day with them, that's for sure.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area, if {PRONOUN/r_c/subject} {VERB/r_c/wish/wishes} to join you. {PRONOUN/r_c/poss/CAP} eyes are wide with horror as {PRONOUN/r_c/subject} {VERB/r_c/scream/screams} out a loud 'no'. r_c calls you a traitor, swinging {PRONOUN/r_c/poss} claws at you, though missing, as you gracefully dodge {PRONOUN/r_c/poss} attack. Sobbing, {PRONOUN/r_c/subject} {VERB/r_c/run/runs} away, deeper into the forest as you can only watch with pity. Your Dark Forest mentor will have a field day with {PRONOUN/r_c/object}, that's for sure.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -772,7 +772,7 @@
                 ]
             },
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area, if they wish to become stronger. r_c is startled before anger bubbles up in them. They call you a traitor, swinging their claws at you to rip your pelt. Snarling, they run away, deeper into the forest as you can only watch with pity. Your Dark Forest mentor will have a field day with them, that's for sure.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area, if {PRONOUN/r_c/subject} {VERB/r_c/wish/wishes} to join you. r_c is startled before anger bubbles up in {PRONOUN/r_c/object}. {PRONOUN/r_c/subject/CAP} {VERB/r_c/call/calls} you a traitor, swinging {PRONOUN/r_c/poss} claws at you to rip your pelt. Snarling, {PRONOUN/r_c/subject} {VERB/r_c/run/runs} away, deeper into the forest as you can only watch with pity. Your Dark Forest mentor will have a field day with {PRONOUN/r_c/object}, that's for sure.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -801,7 +801,7 @@
                     "scar": "This cat was scarred by a Clanmate in the Dark Forest"}
             },
             {
-                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring them to the training area, if they wish to become stronger. r_c calls you a traitor as they refuse, swinging their claws at you though missing as you gracefully dodge their attack. You can't let r_c expose your training like this. Your claws open r_c's throat, and you leave them to fade into the muck. The Clan discovers the horrifying scene in the morning.",
+                "text": "You explain that you're both in the Dark Forest, where you can train to become stronger. You offer to bring {PRONOUN/r_c/object} to the training area, if {PRONOUN/r_c/subject} {VERB/r_c/wish/wishes} to join you. r_c calls you a traitor as {PRONOUN/r_c/subject} {VERB/r_c/refuse/refuses}, swinging {PRONOUN/r_c/poss} claws at you, though missing, as you gracefully dodge {PRONOUN/r_c/poss} attack. You can't let r_c expose your training like this. Your claws open r_c's throat, and you leave {PRONOUN/r_c/object} to fade into the muck. The Clan discovers the horrifying scene in the morning.",
                 "exp": 20,
                 "weight": 10,
                 "dead_cats": ["r_c"],
@@ -846,7 +846,7 @@
         "chance_of_success": 50,
         "success_outcomes": [
             {
-                "text": "It is r_c! They bound towards you, purring that they didn't know anyone else in c_n who trained in the Dark Forest! The two of you walk side by side, discussing training plans, hopes and dreams, and planning your future together as training mates.",
+                "text": "It is r_c! {PRONOUN/r_c/subject/CAP} {VERB/r_c/bound/bounds} towards you, purring that {PRONOUN/r_c/subject} didn't know anyone else in c_n who trained in the Dark Forest! The two of you walk side by side, discussing training plans, hopes and dreams, and planning your future together as training partners.",
                 "exp": 15,
                 "weight": 20,
                 "relationships": [
@@ -876,7 +876,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "You call out to r_c, but as soon as they see you they dart into the brush. When you wake up the next morning, they carefully avoid eye contact.",
+                "text": "You call out to r_c, but as soon as {PRONOUN/r_c/subject} {VERB/r_c/see/sees} you {PRONOUN/r_c/subject} {VERB/r_c/dart/darts} into the brush. When you wake up the next morning, {PRONOUN/r_c/subject} carefully {VERB/r_c/avoid/avoids} eye contact.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -917,7 +917,7 @@
         "chance_of_success": 10,
         "success_outcomes": [
             {
-                "text": "You quickly turn around, only to come eyes to eyes with r_c! They don't seem bothered by your presence, bounding over to you with a welcoming sparkle in their eyes. They seem.. Happy? They explain to you that they've been needing a place to gossip, and when they stumbled over the shadows of the Dark Forest, they couldn't help themselves! Apparently the Clan hasn't been very accepting of their rumors.. But here you are! When you return home from the ever-lasting darkness, you have more secrets than you can carry.",
+                "text": "You quickly turn around, only to come eyes to eyes with r_c! {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} seem bothered by your presence, bounding over to you with a welcoming sparkle in {PRONOUN/r_c/poss} eyes. {PRONOUN/r_c/subject/CAP} {VERB/r_c/seem/seems}.. Happy? {PRONOUN/r_c/subject/CAP} {VERB/r_c/explain/explains} to you that {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} been needing a place to gossip, and when {PRONOUN/r_c/subject} stumbled over the shadows of the Dark Forest, {PRONOUN/r_c/subject} couldn't help {PRONOUN/r_c/self}! Apparently the Clan hasn't been very accepting of {PRONOUN/r_c/poss} rumors.. But here you are! When you return home from the ever-lasting darkness, you have more secrets than you can carry.",
                 "exp": 15,
                 "weight": 20,
                 "relationships": [
@@ -931,7 +931,7 @@
                 ]
             },
             {
-                "text": "You quickly turn around, only to come eyes to eyes with r_c! They don't seem bothered by your presence, bounding over to you with a welcoming sparkle in their eyes. They seem.. Happy? They're thrilled to know that you train here as well and ask to spar. You agree, and when you see them next in camp, it's clear your friendship has grown.",
+                "text": "You quickly turn around, only to come eyes to eyes with r_c! {PRONOUN/r_c/subject/CAP} {VERB/r_c/don't/doesn't} seem bothered by your presence, bounding over to you with a welcoming sparkle in {PRONOUN/r_c/poss} eyes. {PRONOUN/r_c/subject/CAP} {VERB/r_c/seem/seems}.. Happy? {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} thrilled to know that you train here as well and {VERB/r_c/ask/asks} to spar. You agree, and when you see {PRONOUN/r_c/object} next in camp, it's clear your friendship has grown.",
                 "exp": 20,
                 "weight": 20,
                 "relationships": [
@@ -945,7 +945,7 @@
                 ]
             },
             {
-                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. They grab your scruff, dragging you out of the mud. You turn to thank them, and they are relieved to know you're okay. r_c suggests that's enough for you today and you can't help but to agree as you cough up vile mud.",
+                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/grab/grabs} your scruff, dragging you out of the mud. You turn to thank {PRONOUN/r_c/object}, and {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} relieved to know you're okay. r_c suggests that's enough for you today and you can't help but to agree as you cough up vile mud.",
                 "exp": 30,
                 "weight": 20,
                 "relationships": [
@@ -971,7 +971,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. They grab your scruff, dragging you out of the mud. When you turn to thank them, their eyes are wide with horror as they escape your gaze, running away with their tail between their legs and the darkness slowly swallowing them.",
+                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/grab/grabs} your scruff, dragging you out of the mud. When you turn to thank {PRONOUN/r_c/object}, {PRONOUN/r_c/poss} eyes are wide with horror as {PRONOUN/r_c/subject} {VERB/r_c/escape/escapes} your gaze, running away with {PRONOUN/r_c/poss} tail between {PRONOUN/r_c/pos} legs and the darkness slowly swallowing {PRONOUN/r_c/object}.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [
@@ -982,7 +982,7 @@
                 ]
             },
             {
-                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. They are merely standing there watching as the mud starts to swallow you. Keeping calm, you slowly wade your way out despite swallowing a few mouthfuls of mud, only to see r_c disappearing into the darkness.",
+                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} merely standing there watching as the mud starts to swallow you. Keeping calm, you slowly wade your way out despite swallowing a few mouthfuls of mud, only to see r_c disappearing into the darkness.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1006,7 +1006,7 @@
                 }
             },
             {
-                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. They are merely standing there watching as the mud starts to swallow you. There's nothing you can do as you sink down and see r_c disappearing into the darkness. Mud cakes your pelt when the Clan makes the horrifying discovery in the morning.",
+                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} merely standing there watching as the mud starts to swallow you. There's nothing you can do as you sink down and see r_c disappearing into the darkness. Mud cakes your pelt when the Clan makes the horrifying discovery in the morning.",
                 "exp": 0,
                 "weight": 10,
                 "dead_cats": ["y_c"],
@@ -1213,12 +1213,12 @@
         "max_cats": 3,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "While in a group training session with some Clanmates in the Dark Forest, you notice r_c talking to a ghostly cat across the battleground that you haven't met. You can't help but worry for their safety, talking to this unfamiliar cat.",
+        "intro_text": "While in a group training session with some Clanmates in the Dark Forest, you notice r_c talking to a ghostly cat across the battleground that you haven't met. You can't help but worry for {PRONOUN/r_c/poss} safety, talking to this unfamiliar cat.",
         "decline_text": "You shake the feeling of uncertainty and return to training. What your Clanmate gets up to in the Place of No Stars is their business, not yours.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "Weaving through the group of trainees around you, you approach r_c. They greet you with a smile, and their new Dark Forest friend dips their head and introduces themself. Thankfully, it seems that they're friendly!",
+                "text": "Weaving through the group of trainees around you, you approach r_c. {PRONOUN/r_c/subject/CAP} greet you with a smile, and {PRONOUN/r_c/poss} new Dark Forest friend dips their head and introduces themself. Thankfully, it seems that they're friendly!",
                 "exp": 30,
                 "weight": 10,
                 "new_cat": [
@@ -1226,12 +1226,12 @@
                 ]
             },
             {
-                "text": "You manage to dodge your way around the groups of sparring cats around you, but when r_c comes back into view, they're touching noses with the Dark Forest cat, their tails entwined. Concerned, but not wanting to be rude, you turn around to leave them be.",
+                "text": "You manage to dodge your way around the groups of sparring cats around you, but when r_c comes back into view, {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} touching noses with the Dark Forest cat, their tails entwined. Concerned, but not wanting to be rude, you turn around to leave them be.",
                 "exp": 20,
                 "weight": 5
             },
             {
-                "text": "You're able to slip away from your training partner, and when you make your way over to your Clanmate, all you see of their friend is their haunches disappearing into the shadows. r_c explains that they don't like new cats.",
+                "text": "You're able to slip away from your training partner, and when you make your way over to your Clanmate, all you see of {PRONOUN/r_c/poss} friend is their haunches disappearing into the shadows. r_c explains that they don't like new cats.",
                 "exp": 20,
                 "weight": 20
             }
@@ -1255,12 +1255,12 @@
                 }
             },
             {
-                "text": "You dodge through the pairs of sparring spirits to get to your Clanmate, but by the time you get to them, their Dark Forest friend has vanished. You must have scared them off with your approach.",
+                "text": "You dodge through the pairs of sparring spirits to get to your Clanmate, but by the time you get to {PRONOUN/r_c/object}, {PRONOUN/r_c/poss} Dark Forest friend has vanished. You must have scared them off with your approach.",
                 "exp": 0,
                 "weight": 30
             },
             {
-                "text": "You take a step forward to approach your Clanmate, but you feel a swipe at your haunches. Your sparring partner hisses at you to get back to your training. It looks like you won't have any time to go visit r_c. When your sparring session is complete, you can't find them or their new friend anywhere.",
+                "text": "You take a step forward to approach your Clanmate, but you feel a swipe at your haunches. Your sparring partner hisses at you to get back to your training. It looks like you won't have any time to go visit r_c. When your sparring session is complete, you can't find {PRONOUN/r_c/object} or {PRONOUN/r_c/poss} new friend anywhere.",
                 "exp": 0,
                 "weight": 40,
                 "injury": [ 
@@ -1276,7 +1276,7 @@
                 }
             },
             {
-                "text": "You slip away from your training partner, and just as you're able to catch another glimpse of r_c, their Dark Forest friend tackles them to the ground. You figure that they're busy in a training session of their own and leave them be. It isn't until tomorrow morning, when you're awoken by a wail of horror, that you realise what you'd witnessed.",
+                "text": "You slip away from your training partner, and just as you're able to catch another glimpse of r_c, {PRONOUN/r_c/poss} Dark Forest friend tackles {PRONOUN/r_c/object} to the ground. You figure that they're busy in a training session of their own and leave them be. It isn't until tomorrow morning, when you're awoken by a wail of horror, that you realise what you'd witnessed.",
                 "exp": 20,
                 "weight": 5,
                 "dead_cats": ["r_c"]
@@ -1305,16 +1305,16 @@
         "min_max_status": {},
         "weight": 10,
         "intro_text": "After managing to sneak away a brutal group training session, you've managed to find one of the only drinkable water sources in the entire Dark Forest. Just as you start to lift your head from the puddle, a cat tackles you from the side, knocking the air from your lungs. r_c pins you to the ground, looking startled to see you but not backing down.",
-        "decline_text": "You freeze in fear and r_c takes pity. They toss you aside and you instantly sprint away. The water can be all theirs.",
+        "decline_text": "You freeze in fear and r_c takes pity. {PRONOUN/r_c/subject/CAP} {VERB/r_c/toss/tosses} you aside and you instantly sprint away. The water can be all {PRONOUN/r_c/inposs}.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "Taking advantage of r_c's surprise, you launch them into the water and run. You hear them calling out after you, but you don't dare return.",
+                "text": "Taking advantage of r_c's surprise, you launch {PRONOUN/r_c/object} into the water and run. You hear {PRONOUN/r_c/object} calling out after you, but you don't dare return.",
                 "exp": 20,
                 "weight": 20
             },
             {
-                "text": "When they see who you are, r_c jumps off of you, apologising profusely and stating that they just wanted to defend their watering hole. They decide that you can share it, so long as you don't tell anyone else.",
+                "text": "When they see who you are, r_c jumps off of you, apologising profusely and stating that {PRONOUN/r_c/subject} just wanted to defend {PRONOUN/r_c/poss} watering hole. {PRONOUN/r_c/subject/CAP} {VERB/r_c/decide/decides} that you can share it, so long as you don't tell anyone else.",
                 "exp": 20,
                 "weight": 10,
                 "relationships": [
@@ -1347,7 +1347,7 @@
                 }
             },
             {
-                "text": "The shock is enough to startle you awake, and when you see r_c the next morning, they avoid your gaze completely.",
+                "text": "The shock is enough to startle you awake, and when you see r_c the next morning, {PRONOUN/r_c/subject} {VERB/r_c/avoid/avoids} your gaze completely.",
                 "exp": 0,
                 "weight": 30,
                 "relationships": [
@@ -1363,7 +1363,7 @@
         ],
         "antag_fail_outcomes": [
             {
-                "text": "You think that fighting back will be easy, but r_c is a fair match. They know this terrain better than you, and they take advantage of your lack of knowledge to leave you with a nasty injury.",
+                "text": "You think that fighting back will be easy, but r_c is a fair match. {PRONOUN/r_c/subject/CAP} {VERB/r_c/know/knows} this terrain better than you, and {PRONOUN/r_c/subject} {VERB/r_c/take/takes} advantage of your lack of knowledge to leave you with a nasty injury.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [
@@ -1374,7 +1374,7 @@
                 ]
             },
             {
-                "text":"You know you should fight back, but you're equally surprised to see them as r_c is to see you. They're able to get over their shock quicker, though, and they quickly shove you into the water. A paw lands on the back of your head, driving your muzzle into the wet sand. You fight and scream, but you can't reach them. It must be by some grace of StarClan that you manage to startle awake just as your vision starts to flicker.",
+                "text":"You know you should fight back, but you're equally surprised to see them as r_c is to see you. {PRONOUN/r_c/subject/CAP}{VERB/r_c/'re/'s} able to get over {PRONOUN/r_c/poss} shock quicker, though, and {PRONOUN/r_c/subject} quickly {VERB/r_c/shove/shoves} you into the water. A paw lands on the back of your head, driving your muzzle into the wet sand. You fight and scream, but you can't reach {PRONOUN/r_c/object}. It must be by some grace of StarClan that you manage to startle awake just as your vision starts to flicker.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1400,7 +1400,7 @@
         ],
         "antag_success_outcomes": [
             {
-                "text": "While r_c is shocked by the sight of you, you shoot a paw towards their throat. Claws sunk into their neck, you yank them to the ground next to you and take off before they have a chance to react.",
+                "text": "While r_c is shocked by the sight of you, you shoot a paw towards {PRONOUN/r_c/poss} throat. Claws sunk into {PRONOUN/r_c/poss} neck, you yank {PRONOUN/r_c/object} to the ground next to you and take off before {PRONOUN/r_c/subject} {VERB/r_c/have/has} a chance to react.",
                 "exp": 30,
                 "weight": 30,
                 "injury": [
@@ -1417,7 +1417,7 @@
                 }
             },
             {
-                "text": "Angry that r_c was able to catch you off-guard, and knowing that you can't risk them knowing that you train here, you know there's only one way to take care of the situation. You're stronger than your Clanmate-- you know it. Taking advantage of their surprise upon seeing you, you quickly overpower them and sink your teeth into their throat. When the Clan wakes up tomorrow, no one can explain the gorey scene left in r_c's nest.",
+                "text": "Angry that r_c was able to catch you off-guard, and knowing that you can't risk {PRONOUN/r_c/object} knowing that you train here, you know there's only one way to take care of the situation. You're stronger than your Clanmate-- you know it. Taking advantage of {PRONOUN/r_c/poss} surprise upon seeing you, you quickly overpower {PRONOUN/r_c/object} and sink your teeth into {PRONOUN/r_c/poss} throat. When the Clan wakes up tomorrow, no one can explain the gorey scene left in r_c's nest.",
                 "exp": 40,
                 "weight": 10,
                 "dead_cats": ["r_c"],
@@ -1453,39 +1453,39 @@
         "max_cats": 3,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "You're taking a break from your training one night when you hear a loud splash behind you. Out of a nearby lake crawls r_c, gasping for air and looking horrified. Face covered in muck, they haven't yet noticed you.",
-        "decline_text": "You're not equipped to deal with this. Startled, you stand and run before they have a chance to open their eyes.",
+        "intro_text": "You're taking a break from your training one night when you hear a loud splash behind you. Out of a nearby lake crawls r_c, gasping for air and looking horrified. Face covered in muck, {PRONOUN/r_c/subject} {VERB/r_c/haven't/hasn't} yet noticed you.",
+        "decline_text": "You're not equipped to deal with this. Startled, you stand and run before {PRONOUN/r_c/subject} {VERB/r_c/have/has} a chance to open {PRONOUN/r_c/poss} eyes.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "You instantly leap forward to grab r_c's shoulders and pull them from the lake. You use a gentle paw to wipe the mud from their eyes, and when they finally open them, they express how relieved that are to see you. Apparently, they've gotten lost in their sleep somehow, and they desperately want to find a way out. You point them to a safe, secluded area where they can drift off in peace and wake up back in camp.",
+                "text": "You instantly leap forward to grab r_c's shoulders and pull {PRONOUN/r_c/object} from the lake. You use a gentle paw to wipe the mud from {PRONOUN/r_c/poss} eyes, and when {PRONOUN/r_c/subject} finally {VERB/r_c/open/opens} them, {PRONOUN/r_c/subject} {VERB/r_c/express/expresses} how relieved {PRONOUN/r_c/subject} {VERB/r_c/are/is} to see you. Apparently, {PRONOUN/r_c/subject}{VERB/r_c/'ve/'s} gotten lost in {PRONOUN/r_c/poss} sleep somehow, and {PRONOUN/r_c/subject} desperately {VERB/r_c/want/wants} to find a way out. You point {PRONOUN/r_c/object} to a safe, secluded area where {PRONOUN/r_c/subject} can drift off in peace and wake up back in camp.",
                 "exp": 20,
                 "weight": 20
             },
             {
-                "text": "You reach out a paw, and the sightless r_c instantly grabs hold to pull themselves out of the lake. While they sit on safe land, hacking and sputtering while wiping the muck from their eyes, you make the decision to run before they're able to see you.",
+                "text": "You reach out a paw, and the sightless r_c instantly grabs hold to pull {PRONOUN/r_c/self} out of the lake. While {PRONOUN/r_c/subject} {VERB/r_c/sit/sits} on safe land, hacking, sputtering, and wiping the muck from {PRONOUN/r_c/poss} eyes, you make the decision to run before {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} able to see you.",
                 "exp": 20,
                 "weight": 20
             },
             {
-                "text": "As r_c manages to pull themselves up onto shore, you keep careful watch to make sure no hostile warriors pop out of the shadows to attack them while they can't see. Once they catch their breath and wipe the muck from their eyes, they look happy to see you, and thank you for saving them. When they ask where they are, you avoid answering the question, simply telling them not to worry, and that they'll wake up soon.",
+                "text": "As r_c manages to pull {PRONOUN/r_c/self} up onto shore, you keep careful watch to make sure no hostile warriors pop out of the shadows to attack {PRONOUN/r_c/object} while {PRONOUN/r_c/subject} can't see. Once {PRONOUN/r_c/subject} {VERB/r_c/catch/catches} {PRONOUN/r_c/poss} breath and {VERB/r_c/wipe/wipes} the muck from {PRONOUN/r_c/poss} eyes, {PRONOUN/r_c/subject} {VERB/r_c/look/looks} happy to see you, and {VERB/r_c/thank/thanks} you for saving {PRONOUN/r_c/object}. When {PRONOUN/r_c/subject} {VERB/r_c/ask/asks} where {PRONOUN/r_c/subject} {VERB/r_c/are/is}, you avoid answering the question, simply telling {PRONOUN/r_c/object} not to worry, and that {PRONOUN/r_c/subject}'ll wake up soon.",
                 "exp": 20,
                 "weight": 20
             }
         ],
         "fail_outcomes": [
             {
-                "text": "You reach forward to help pull your Clanmate out of the water. When they see who it is that saved them, however, they hiss, appalled that you'd betray your Clan by training in such a place. r_c runs off before you can ask what <i>they're</i> doing here.",
+                "text": "You reach forward to help pull your Clanmate out of the water. When {PRONOUN/r_c/subject} {VERB/r_c/see/sees} who it is that saved {PRONOUN/r_c/object}, however, {PRONOUN/r_c/subject} {VERB/r_c/hiss/hisses}, appalled that you'd betray your Clan by training in such a place. r_c runs off before you can ask what <i>{PRONOUN/r_c/subject}{VERB/r_c/'re/'s}</i> doing here.",
                 "exp": 0,
                 "weight": 20
             },
             {
-                "text": "You reach forward to help pull your Clanmate out of the water, but at your touch, they jump, push your paws away, and slip back underneath. Panicked, you try to reach down into the opaque water to find them again, but r_c's head doesn't resurface. You instantly wake and rush to their nest to shake them awake. They just swat at you, annoyed that you interrupted their dream.",
+                "text": "You reach forward to help pull your Clanmate out of the water, but at your touch, {PRONOUN/r_c/subject} {VERB/r_c/jump/jumps}, push your paws away, and slip back underneath. Panicked, you try to reach down into the opaque water to find {PRONOUN/r_c/object} again, but r_c's head doesn't resurface. You instantly wake and rush to {PRONOUN/r_c/poss} nest to shake them awake. {PRONOUN/r_c/subject/CAP} just {VERB/r_c/swat/swats} at you, annoyed that you interrupted {PRONOUN/r_c/poss} dream.",
                 "exp": 0,
                 "weight": 30
             },
             {
-                "text": "When you reach forward to try to pull them out, r_c swats your paws away, mistaking you for a threat. As they try to climb up onto the bank themselves, eyes blinded by the filthy lakewater, the ground crumbles away, sending them back into the lake. It take you longer than you'd like to will yourself awake, and when it finally works, you can already hear r_c hacking and coughing from their nest.",
+                "text": "When you reach forward to try to pull {PRONOUN/r_c/object} out, r_c swats your paws away, mistaking you for a threat. As {PRONOUN/r_c/subject} {VERB/r_c/try/tries} to climb up onto the bank {PRONOUN/r_c/self}, eyes blinded by the filthy lakewater, the ground crumbles away, sending {PRONOUN/r_c/object} back into the lake. It take you longer than you'd like to will yourself awake, and when it finally works, you can already hear r_c hacking and coughing from {PRONOUN/r_c/poss} nest.",
                 "exp": 0,
                 "weight": 40,
                 "injury": [ 
@@ -1500,7 +1500,7 @@
                 }
             },
             {
-                "text": "You rush forward to help your Clanmate out of the water, but they grab onto your forelegs as they struggle, threatening to pull you down with them. All you can do is loosen their grip on your legs to save your own life, and with nothing to hold on to, r_c quickly slips back underneath the surface. You don't attempt to reach for them again, knowing that the thick muck of the lake is inescapable. You're proven right when you're awoken the next morning by a grief-stricken wail.",
+                "text": "You rush forward to help your Clanmate out of the water, but {PRONOUN/r_c/subject} {VERB/r_c/grab/grabs} onto your forelegs as {PRONOUN/r_c/subject} {VERB/r_c/struggle/struggles}, threatening to pull you down with {PRONOUN/r_c/object}. All you can do is loosen {PRONOUN/r_c/poss} grip on your legs to save your own life, and with nothing to hold on to, r_c quickly slips back underneath the surface. You don't attempt to reach for {PRONOUN/r_c/object} again, knowing that the thick muck of the lake is inescapable. You're proven right when you're awoken the next morning by a grief-stricken wail.",
                 "exp": 0,
                 "weight": 5,
                 "dead_cats": ["r_c"],
@@ -1530,17 +1530,17 @@
         "max_cats": 2,
         "min_max_status": {},
         "weight": 20,
-        "intro_text": "After falling asleep close to r_c one night, you awaken in the Dark Forest, as usual. What's not usual is that r_c is right next to you, ears pinned and glancing around in horror. They turn to you and ask what's going on.",
+        "intro_text": "After falling asleep close to r_c one night, you awaken in the Dark Forest, as usual. What's not usual is that r_c is right next to you, ears pinned and glancing around in horror. {PRONOUN/r_c/subject/CAP} {VERB/r_c/turn/turns} to you and {VERB/r_c/ask/asks} what's going on.",
         "decline_text": "You can't think of what to say, and your anxiety startles you awake. You quickly stand up to sleep somewhere much farther away.",
         "chance_of_success": 30,
         "success_outcomes": [
             {
-                "text": "You decide to feign fear. You begin to twitch your tail and observe the Dark Forest with mock anxiety, telling them that you don't know. You're able to methodically guide them to a safe place, where you can both fall asleep and wake up back in camp unharmed.",
+                "text": "You decide to feign fear. You begin to twitch your tail and observe the Dark Forest with mock anxiety, telling {PRONOUN/r_c/object} that you don't know. You're able to methodically guide {PRONOUN/r_c/object} to a safe place, where you can both fall asleep and wake up back in camp unharmed.",
                 "exp": 20,
                 "weight": 20
             },
             {
-                "text": "You decide to be truthful. You tell r_c that you're in the Dark Forest, but it's okay, because you can get them out. r_c follows your lead as you guide them to a safe place, and you keep watch while they fall asleep. You watch their pelt fade as they wake up in the real world, glad they're safe.",
+                "text": "You decide to be truthful. You tell r_c that you're in the Dark Forest, but it's okay, because you can get {PRONOUN/r_c/object} out. r_c follows your lead as you guide {PRONOUN/r_c/object} to a safe place, and you keep watch while {PRONOUN/r_c/subject} {VERB/r_c/fall/falls} asleep. You watch {PRONOUN/r_c/poss} pelt fade as {PRONOUN/r_c/subject} {VERB/r_c/wake/wakes} up in the real world, glad {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} safe.",
                 "exp": 20,
                 "weight": 20,
                 "relationships": [
@@ -1554,7 +1554,7 @@
                 ]
             },
             {
-                "text": "You tell r_c that you're in the Dark Forest, where Clan cats can train to grow stronger. Though anxious at first, they begin to grow more comfortable as you show them around. After meeting with your mentor and several other Dark Forest warriors, they decide to stay!",
+                "text": "You tell r_c that you're in the Dark Forest, where Clan cats can train to grow stronger. Though anxious at first, {PRONOUN/r_c/subject} {VERB/r_c/begin/begins} to grow more comfortable as you show {PRONOUN/r_c/object} around. After meeting with your mentor and several other Dark Forest warriors, {PRONOUN/r_c/subject} {VERB/r_c/decide/decides} to stay!",
                 "exp": 20,
                 "weight": 10,
                 "convert": ["r_c"],
@@ -1568,7 +1568,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "When you tell r_c that you're in the Dark Forest, they hiss and call you a traitor. Before you can try to remedy the situation, they run off, passing a group of Dark Forest warriors, who instantly give chase.",
+                "text": "When you tell r_c that you're in the Dark Forest, {PRONOUN/r_c/subject} {VERB/r_c/hiss/hisses} and {VERB/r_c/call/calls} you a traitor. Before you can try to remedy the situation, {PRONOUN/r_c/subject} {VERB/r_c/run/runs} off, passing a group of Dark Forest warriors, who instantly give chase.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [ 
@@ -1592,7 +1592,7 @@
                 ]
             },
             {
-                "text": "When you tell them you're in the Dark Forest, r_c calls you a traitor and a coward. You tell them that they're no better for also ending up here, and your petty argument lasts until the rising sun wakes you up. r_c shoves you away when you wake up, and you vow to never sleep near them again.",
+                "text": "When you tell {PRONOUN/r_c/object} you're in the Dark Forest, r_c calls you a traitor and a coward. You tell {PRONOUN/r_c/object} that {PRONOUN/r_c/subject}{VERB/r_c/'re/'s} no better for also ending up here, and your petty argument lasts until the rising sun wakes you up. r_c shoves you away when you wake up, and you vow to never sleep near {PRONOUN/r_c/object} again.",
                 "exp": 0,
                 "weight": 30,
                 "relationships": [
@@ -1608,7 +1608,7 @@
         ],
         "antag_fail_outcomes": [
             {
-                "text": "You can't have r_c knowing you train here. Instantly, you leap to attack them, but they sidestep your attack and bolt into the shadows, effectively disappearing from your view.",
+                "text": "You can't have r_c knowing you train here. Instantly, you leap to attack {PRONOUN/r_c/object}, but {PRONOUN/r_c/subject} {VERB/r_c/sidestep/sidesteps} your attack and {VERB/r_c/bolt/bolts} into the shadows, effectively disappearing from your view.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [
@@ -1622,19 +1622,19 @@
                 ]
             },
             {
-                "text":"You growl at r_c not to ask such stupid questions, but they don't seem intimidated. Hardly taking notice of your threat, they stumble off into the shadows in a panicked daze.",
+                "text":"You growl at r_c not to ask such stupid questions, but {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} seem intimidated. Hardly taking notice of your threat, {PRONOUN/r_c/subject} {VERB/r_c/stumble/stumbles} off into the shadows in a panicked daze.",
                 "exp": 0,
                 "weight": 20
             }
         ],
         "antag_success_outcomes": [
             {
-                "text": "You growl at r_c not to ask such stupid questions and they shrink, muttering a quick apology. You leave them there to go do your training.",
+                "text": "You growl at r_c not to ask such stupid questions and {PRONOUN/r_c/subject} {VERB/r_c/shrink/shrinks}, muttering a quick apology. You leave {PRONOUN/r_c/object} there to go do your training.",
                 "exp": 30,
                 "weight": 20
             },
             {
-                "text": "You instantly throw your unsheathed claws at r_c's face, and they recoil at the hit. You tell them not to tell a soul that they saw you here, and you leave them to do your training, blood dripping from their newly injured eye.",
+                "text": "You instantly throw your unsheathed claws at r_c's face, and {PRONOUN/r_c/subject} {VERB/r_c/recoil/recoils} at the hit. You tell {PRONOUN/r_c/object} not to tell a soul that {PRONOUN/r_c/subject} saw you here, and you leave {PRONOUN/r_c/object} to do your training, blood dripping from {PRONOUN/r_c/poss} newly injured eye.",
                 "exp": 40,
                 "weight": 10,
                 "injury": [

--- a/resources/dicts/patrols/lifegen/df.json
+++ b/resources/dicts/patrols/lifegen/df.json
@@ -373,7 +373,7 @@
                 "exp": 20,
                 "weight": 20,
                 "new_cat": [
-                    ["newdfcat", "oldstarClan"]
+                    ["newdfcat", "oldstarclan"]
                 ]
             }
         ],

--- a/resources/dicts/patrols/lifegen/df.json
+++ b/resources/dicts/patrols/lifegen/df.json
@@ -971,7 +971,7 @@
         ],
         "fail_outcomes": [
             {
-                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/grab/grabs} your scruff, dragging you out of the mud. When you turn to thank {PRONOUN/r_c/object}, {PRONOUN/r_c/poss} eyes are wide with horror as {PRONOUN/r_c/subject} {VERB/r_c/escape/escapes} your gaze, running away with {PRONOUN/r_c/poss} tail between {PRONOUN/r_c/pos} legs and the darkness slowly swallowing {PRONOUN/r_c/object}.",
+                "text": "The feeling won't leave you alone, rather increases. It feels like hundreds of ants are crawling in your fur, dragging you downwards into the mud. You turn around, yelping, and come face to face with r_c. {PRONOUN/r_c/subject/CAP} {VERB/r_c/grab/grabs} your scruff, dragging you out of the mud. When you turn to thank {PRONOUN/r_c/object}, {PRONOUN/r_c/poss} eyes are wide with horror as {PRONOUN/r_c/subject} {VERB/r_c/escape/escapes} your gaze, running away with {PRONOUN/r_c/poss} tail between {PRONOUN/r_c/poss} legs and the darkness slowly swallowing {PRONOUN/r_c/object}.",
                 "exp": 0,
                 "weight": 20,
                 "injury": [

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2360,7 +2360,8 @@ class Events:
             return
         
         if not cat.outside and not cat.exiled:
-            self.handle_apprentice_EX(cat)  # This must be before perform_ceremonies!
+            if cat.shunned == 0:
+                self.handle_apprentice_EX(cat)  # This must be before perform_ceremonies!
             # this HAS TO be before the cat.is_disabled() so that disabled kits can choose a med cat or mediator position
             self.perform_ceremonies(cat)
         cat.skills.progress_skill(cat) # This must be done after ceremonies. 
@@ -2735,7 +2736,7 @@ class Events:
             if cat.status in [
                 "apprentice", "mediator apprentice",
                 "medicine cat apprentice", "queen's apprentice"
-            ]:
+            ] and cat.shunned == 0:
 
                 if game.clan.clan_settings["12_moon_graduation"]:
                     _ready = cat.moons >= 12
@@ -2802,235 +2803,241 @@ class Events:
         promote cats and add to event list
         """
         # ceremony = []
-        if cat.shunned == 0:
-            _ment = Cat.fetch_cat(cat.mentor) if cat.mentor else None # Grab current mentor, if they have one, before it's removed. 
-            old_name = str(cat.name)
-            cat.status_change(promoted_to)
-            cat.rank_change_traits_skill(_ment)
+        _ment = Cat.fetch_cat(cat.mentor) if cat.mentor else None # Grab current mentor, if they have one, before it's removed. 
+        old_name = str(cat.name)
+        cat.status_change(promoted_to)
+        cat.rank_change_traits_skill(_ment)
 
-            involved_cats = [
-                cat.ID
-            ]  # Clearly, the cat the ceremony is about is involved.
+        involved_cats = [
+            cat.ID
+        ]  # Clearly, the cat the ceremony is about is involved.
 
-            # Time to gather ceremonies. First, lets gather all the ceremony ID's.
-            possible_ceremonies = set()
-            dead_mentor = None
-            mentor = None
-            previous_alive_mentor = None
-            dead_parents = []
-            living_parents = []
-            mentor_type = {
-                "medicine cat": ["medicine cat"],
-                "queen": ["queen"],
-                "warrior": ["warrior", "deputy", "leader", "elder"],
-                "mediator": ["mediator"]
-            }
+        # Time to gather ceremonies. First, lets gather all the ceremony ID's.
+        possible_ceremonies = set()
+        dead_mentor = None
+        mentor = None
+        previous_alive_mentor = None
+        dead_parents = []
+        living_parents = []
+        mentor_type = {
+            "medicine cat": ["medicine cat"],
+            "queen": ["queen"],
+            "warrior": ["warrior", "deputy", "leader", "elder"],
+            "mediator": ["mediator"]
+        }
 
-            try:
-                # Get all the ceremonies for the role ----------------------------------------
-                possible_ceremonies.update(self.ceremony_id_by_tag[promoted_to])
+        try:
+            # Get all the ceremonies for the role ----------------------------------------
+            possible_ceremonies.update(self.ceremony_id_by_tag[promoted_to])
 
-                # Get ones for prepared status ----------------------------------------------
-                if promoted_to in ["warrior", "medicine cat", "mediator", "queen"]:
-                    possible_ceremonies = possible_ceremonies.intersection(
-                        self.ceremony_id_by_tag[preparedness])
+            # Get ones for prepared status ----------------------------------------------
+            if promoted_to in ["warrior", "medicine cat", "mediator", "queen"]:
+                possible_ceremonies = possible_ceremonies.intersection(
+                    self.ceremony_id_by_tag[preparedness])
 
-                # Gather ones for mentor. -----------------------------------------------------
-                tags = []
+            # Gather ones for mentor. -----------------------------------------------------
+            tags = []
 
-                # CURRENT MENTOR TAG CHECK
-                if cat.mentor:
-                    if Cat.fetch_cat(cat.mentor).status == "leader":
-                        tags.append("yes_leader_mentor")
-                    else:
-                        tags.append("yes_mentor")
-                    mentor = Cat.fetch_cat(cat.mentor)
+            # CURRENT MENTOR TAG CHECK
+            if cat.mentor:
+                if Cat.fetch_cat(cat.mentor).status == "leader":
+                    tags.append("yes_leader_mentor")
                 else:
-                    tags.append("no_mentor")
+                    tags.append("yes_mentor")
+                mentor = Cat.fetch_cat(cat.mentor)
+            else:
+                tags.append("no_mentor")
 
-                for c in reversed(cat.former_mentor):
-                    if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
-                        tags.append("dead_mentor")
-                        dead_mentor = Cat.fetch_cat(c)
-                        break
+            if cat.shunned > 0:
+                tags.append("shunned")
 
-                # Unlike dead mentors, living mentors must be VALID
-                # they must have the correct status for the role the cat
-                # is being promoted too.
-                valid_living_former_mentors = []
-                for c in cat.former_mentor:
-                    if not (Cat.fetch_cat(c).dead or Cat.fetch_cat(c).outside or Cat.fetch_cat(c).shunned > 0):
-                        if promoted_to in mentor_type:
-                            if Cat.fetch_cat(c).status in mentor_type[promoted_to]:
-                                valid_living_former_mentors.append(c)
-                        else:
+            for c in reversed(cat.former_mentor):
+                if Cat.fetch_cat(c) and Cat.fetch_cat(c).dead:
+                    tags.append("dead_mentor")
+                    dead_mentor = Cat.fetch_cat(c)
+                    break
+
+            # Unlike dead mentors, living mentors must be VALID
+            # they must have the correct status for the role the cat
+            # is being promoted too.
+            valid_living_former_mentors = []
+            for c in cat.former_mentor:
+                if not (Cat.fetch_cat(c).dead or Cat.fetch_cat(c).outside or Cat.fetch_cat(c).shunned > 0):
+                    if promoted_to in mentor_type:
+                        if Cat.fetch_cat(c).status in mentor_type[promoted_to]:
                             valid_living_former_mentors.append(c)
-
-                # ALL FORMER MENTOR TAG CHECKS
-                if valid_living_former_mentors:
-                    #  Living Former mentors. Grab the latest living valid mentor.
-                    previous_alive_mentor = Cat.fetch_cat(
-                        valid_living_former_mentors[-1])
-                    if previous_alive_mentor.status == "leader":
-                        tags.append("alive_leader_mentor")
                     else:
-                        tags.append("alive_mentor")
+                        valid_living_former_mentors.append(c)
+
+            # ALL FORMER MENTOR TAG CHECKS
+            if valid_living_former_mentors:
+                #  Living Former mentors. Grab the latest living valid mentor.
+                previous_alive_mentor = Cat.fetch_cat(
+                    valid_living_former_mentors[-1])
+                if previous_alive_mentor.status == "leader":
+                    tags.append("alive_leader_mentor")
                 else:
-                    # This tag means the cat has no living, valid mentors.
-                    tags.append("no_valid_previous_mentor")
+                    tags.append("alive_mentor")
+            else:
+                # This tag means the cat has no living, valid mentors.
+                tags.append("no_valid_previous_mentor")
 
-                # Now we add the mentor stuff:
-                temp = possible_ceremonies.intersection(
-                    self.ceremony_id_by_tag["general_mentor"])
+            # Now we add the mentor stuff:
+            temp = possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["general_mentor"])
 
-                for t in tags:
-                    temp.update(
-                        possible_ceremonies.intersection(
-                            self.ceremony_id_by_tag[t]))
+            for t in tags:
+                temp.update(
+                    possible_ceremonies.intersection(
+                        self.ceremony_id_by_tag[t]))
 
-                possible_ceremonies = temp
+            possible_ceremonies = temp
 
-                # Gather for parents ---------------------------------------------------------
-                for p in [cat.parent1, cat.parent2]:
-                    if Cat.fetch_cat(p):
-                        if Cat.fetch_cat(p).dead:
-                            dead_parents.append(Cat.fetch_cat(p))
-                        # For the purposes of ceremonies, living parents
-                        # who are also the leader are not counted.
-                        elif not Cat.fetch_cat(p).dead and not Cat.fetch_cat(p).outside and \
-                                Cat.fetch_cat(p).status != "leader":
-                            living_parents.append(Cat.fetch_cat(p))
+            # Gather for parents ---------------------------------------------------------
+            for p in [cat.parent1, cat.parent2]:
+                if Cat.fetch_cat(p):
+                    if Cat.fetch_cat(p).dead:
+                        dead_parents.append(Cat.fetch_cat(p))
+                    # For the purposes of ceremonies, living parents
+                    # who are also the leader are not counted.
+                    elif not Cat.fetch_cat(p).dead and not Cat.fetch_cat(p).outside and \
+                            Cat.fetch_cat(p).status != "leader":
+                        living_parents.append(Cat.fetch_cat(p))
 
-                tags = []
-                if len(dead_parents) >= 1 and "orphaned" not in cat.backstory:
-                    tags.append("dead1_parents")
-                if len(dead_parents) >= 2 and "orphaned" not in cat.backstory:
-                    tags.append("dead1_parents")
-                    tags.append("dead2_parents")
+            tags = []
+            if len(dead_parents) >= 1 and "orphaned" not in cat.backstory:
+                tags.append("dead1_parents")
+            if len(dead_parents) >= 2 and "orphaned" not in cat.backstory:
+                tags.append("dead1_parents")
+                tags.append("dead2_parents")
 
-                if len(living_parents) >= 1:
-                    tags.append("alive1_parents")
-                if len(living_parents) >= 2:
-                    tags.append("alive2_parents")
+            if len(living_parents) >= 1:
+                tags.append("alive1_parents")
+            if len(living_parents) >= 2:
+                tags.append("alive2_parents")
 
-                temp = possible_ceremonies.intersection(
-                    self.ceremony_id_by_tag["general_parents"])
+            temp = possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["general_parents"])
 
-                for t in tags:
-                    temp.update(
-                        possible_ceremonies.intersection(
-                            self.ceremony_id_by_tag[t]))
+            for t in tags:
+                temp.update(
+                    possible_ceremonies.intersection(
+                        self.ceremony_id_by_tag[t]))
 
-                possible_ceremonies = temp
+            possible_ceremonies = temp
 
-                # Gather for leader ---------------------------------------------------------
+            # Gather for leader ---------------------------------------------------------
 
-                tags = []
-                if game.clan.leader and not game.clan.leader.dead and not game.clan.leader.outside and game.clan.leader.shunned == 0:
-                    tags.append("yes_leader")
-                else:
-                    tags.append("no_leader")
+            tags = []
+            if game.clan.leader and not game.clan.leader.dead and not game.clan.leader.outside and game.clan.leader.shunned == 0:
+                tags.append("yes_leader")
+            else:
+                tags.append("no_leader")
 
-                temp = possible_ceremonies.intersection(
-                    self.ceremony_id_by_tag["general_leader"])
+            temp = possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["general_leader"])
 
-                for t in tags:
-                    temp.update(
-                        possible_ceremonies.intersection(
-                            self.ceremony_id_by_tag[t]))
+            for t in tags:
+                temp.update(
+                    possible_ceremonies.intersection(
+                        self.ceremony_id_by_tag[t]))
 
-                possible_ceremonies = temp
+            possible_ceremonies = temp
 
-                # Gather for backstories.json ----------------------------------------------------
-                tags = []
-                if cat.backstory == ['abandoned1', 'abandoned2', 'abandoned3']:
-                    tags.append("abandoned")
-                elif cat.backstory == "clanborn":
-                    tags.append("clanborn")
+            # Gather for backstories.json ----------------------------------------------------
+            tags = []
+            if cat.backstory == ['abandoned1', 'abandoned2', 'abandoned3']:
+                tags.append("abandoned")
+            elif cat.backstory == "clanborn":
+                tags.append("clanborn")
 
-                temp = possible_ceremonies.intersection(
-                    self.ceremony_id_by_tag["general_backstory"])
+            temp = possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["general_backstory"])
 
-                for t in tags:
-                    temp.update(
-                        possible_ceremonies.intersection(
-                            self.ceremony_id_by_tag[t]))
+            for t in tags:
+                temp.update(
+                    possible_ceremonies.intersection(
+                        self.ceremony_id_by_tag[t]))
 
-                possible_ceremonies = temp
-                # Gather for traits --------------------------------------------------------------
+            possible_ceremonies = temp
+            # Gather for traits --------------------------------------------------------------
 
-                temp = possible_ceremonies.intersection(
-                    self.ceremony_id_by_tag["all_traits"])
-
-                if cat.personality.trait in self.ceremony_id_by_tag:
-                    temp.update(
-                        possible_ceremonies.intersection(
-                            self.ceremony_id_by_tag[cat.personality.trait]))
-
-                possible_ceremonies = temp
-            except Exception as ex:
-                traceback.print_exception(type(ex), ex, ex.__traceback__)
-                print("Issue gathering ceremony text.", str(cat.name), promoted_to)
-
-            # getting the random honor if it's needed
-            random_honor = None
-            if promoted_to in ['warrior', 'mediator', 'medicine cat', "queen"]:
-                resource_dir = "resources/dicts/events/ceremonies/"
-                with open(f"{resource_dir}ceremony_traits.json",
-                        encoding="ascii") as read_file:
-                    TRAITS = ujson.loads(read_file.read())
-                try:
-                    random_honor = random.choice(TRAITS[cat.personality.trait])
-                except KeyError:
-                    random_honor = "hard work"
-
-            if cat.status in ["warrior", "medicine cat", "mediator", "queen"]:
-                History.add_app_ceremony(cat, random_honor)
+            temp = possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["all_traits"])
             
-            ceremony_tags, ceremony_text = self.CEREMONY_TXT[random.choice(
-                list(possible_ceremonies))]
+            if cat.shunned:
+                temp.update(possible_ceremonies.intersection(
+                self.ceremony_id_by_tag["shunned"]))
 
-            # This is a bit strange, but it works. If there is
-            # only one parent involved, but more than one living
-            # or dead parent, the adjust text function will pick
-            # a random parent. However, we need to know the
-            # parent to include in the involved cats. Therefore,
-            # text adjust also returns the random parents it picked,
-            # which will be added to the involved cats if needed.
-            ceremony_text, involved_living_parent, involved_dead_parent = \
-                ceremony_text_adjust(Cat, ceremony_text, cat, dead_mentor=dead_mentor,
-                                    random_honor=random_honor, old_name=old_name,
-                                    mentor=mentor, previous_alive_mentor=previous_alive_mentor,
-                                    living_parents=living_parents, dead_parents=dead_parents)
+            if cat.personality.trait in self.ceremony_id_by_tag:
+                temp.update(
+                    possible_ceremonies.intersection(
+                        self.ceremony_id_by_tag[cat.personality.trait]))
 
-            # Gather additional involved cats
-            for tag in ceremony_tags:
-                if tag == "yes_leader":
-                    involved_cats.append(game.clan.leader.ID)
-                elif tag in ["yes_mentor", "yes_leader_mentor"]:
-                    involved_cats.append(cat.mentor)
-                elif tag == "dead_mentor":
-                    involved_cats.append(dead_mentor.ID)
-                elif tag in ["alive_mentor", "alive_leader_mentor"]:
-                    involved_cats.append(previous_alive_mentor.ID)
-                elif tag == "alive2_parents" and len(living_parents) >= 2:
-                    for c in living_parents[:2]:
-                        involved_cats.append(c.ID)
-                elif tag == "alive1_parents" and involved_living_parent:
-                    involved_cats.append(involved_living_parent.ID)
-                elif tag == "dead2_parents" and len(dead_parents) >= 2:
-                    for c in dead_parents[:2]:
-                        involved_cats.append(c.ID)
-                elif tag == "dead1_parent" and involved_dead_parent:
-                    involved_cats.append(involved_dead_parent.ID)
+            possible_ceremonies = temp
+        except Exception as ex:
+            traceback.print_exception(type(ex), ex, ex.__traceback__)
+            print("Issue gathering ceremony text.", str(cat.name), promoted_to)
 
-            # remove duplicates
-            involved_cats = list(set(involved_cats))
-            if cat.ID != game.clan.your_cat.ID and game.clan.your_cat.ID != cat.mentor:
-                game.cur_events_list.append(
-                    Single_Event(f'{ceremony_text}', "ceremony", involved_cats))
-            cat.faith += round(random.uniform(0,2), 2)
-            game.ceremony_events_list.append(f'{cat.name}{ceremony_text}')
+        # getting the random honor if it's needed
+        random_honor = None
+        if promoted_to in ['warrior', 'mediator', 'medicine cat', "queen"]:
+            resource_dir = "resources/dicts/events/ceremonies/"
+            with open(f"{resource_dir}ceremony_traits.json",
+                    encoding="ascii") as read_file:
+                TRAITS = ujson.loads(read_file.read())
+            try:
+                random_honor = random.choice(TRAITS[cat.personality.trait])
+            except KeyError:
+                random_honor = "hard work"
+
+        if cat.status in ["warrior", "medicine cat", "mediator", "queen"]:
+            History.add_app_ceremony(cat, random_honor)
+        
+        ceremony_tags, ceremony_text = self.CEREMONY_TXT[random.choice(
+            list(possible_ceremonies))]
+
+        # This is a bit strange, but it works. If there is
+        # only one parent involved, but more than one living
+        # or dead parent, the adjust text function will pick
+        # a random parent. However, we need to know the
+        # parent to include in the involved cats. Therefore,
+        # text adjust also returns the random parents it picked,
+        # which will be added to the involved cats if needed.
+        ceremony_text, involved_living_parent, involved_dead_parent = \
+            ceremony_text_adjust(Cat, ceremony_text, cat, dead_mentor=dead_mentor,
+                                random_honor=random_honor, old_name=old_name,
+                                mentor=mentor, previous_alive_mentor=previous_alive_mentor,
+                                living_parents=living_parents, dead_parents=dead_parents)
+
+        # Gather additional involved cats
+        for tag in ceremony_tags:
+            if tag == "yes_leader":
+                involved_cats.append(game.clan.leader.ID)
+            elif tag in ["yes_mentor", "yes_leader_mentor"]:
+                involved_cats.append(cat.mentor)
+            elif tag == "dead_mentor":
+                involved_cats.append(dead_mentor.ID)
+            elif tag in ["alive_mentor", "alive_leader_mentor"]:
+                involved_cats.append(previous_alive_mentor.ID)
+            elif tag == "alive2_parents" and len(living_parents) >= 2:
+                for c in living_parents[:2]:
+                    involved_cats.append(c.ID)
+            elif tag == "alive1_parents" and involved_living_parent:
+                involved_cats.append(involved_living_parent.ID)
+            elif tag == "dead2_parents" and len(dead_parents) >= 2:
+                for c in dead_parents[:2]:
+                    involved_cats.append(c.ID)
+            elif tag == "dead1_parent" and involved_dead_parent:
+                involved_cats.append(involved_dead_parent.ID)
+
+        # remove duplicates
+        involved_cats = list(set(involved_cats))
+        if cat.ID != game.clan.your_cat.ID and game.clan.your_cat.ID != cat.mentor:
+            game.cur_events_list.append(
+                Single_Event(f'{ceremony_text}', "ceremony", involved_cats))
+        cat.faith += round(random.uniform(0,2), 2)
+        game.ceremony_events_list.append(f'{cat.name}{ceremony_text}')
 
 
     def gain_accessories(self, cat):

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -1468,7 +1468,8 @@ class DeathScreen(UIWindow):
                 game.clan.your_cat.revives +=1
                 game.clan.your_cat.dead = False
                 game.clan.your_cat.df = False
-                game.clan.your_cat.outside = False
+                if not game.clan.your_cat.outside:
+                    game.clan.your_cat.outside = False
                 game.clan.your_cat.dead_for = 0
                 game.clan.your_cat.moons+=1
                 game.clan.your_cat.update_mentor()

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -360,9 +360,7 @@ class Patrol():
                 possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_HOSTILE))
 
         if game.current_screen == 'patrol screen' or game.current_screen == 'patrol screen2' or game.current_screen =='patrol screen3' or game.current_screen =='patrol screen4':
-            # final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, camp, current_season,
-            #                                                                 patrol_type)
-            final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, current_season,
+            final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, camp, current_season,
                                                                             patrol_type)
             
 

--- a/scripts/patrol/patrol.py
+++ b/scripts/patrol/patrol.py
@@ -358,7 +358,9 @@ class Patrol():
                 possible_patrols.extend(self.generate_patrol_events(self.OTHER_CLAN_HOSTILE))
 
         if game.current_screen == 'patrol screen' or game.current_screen == 'patrol screen2' or game.current_screen =='patrol screen3' or game.current_screen =='patrol screen4':
-            final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, camp, current_season,
+            # final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, camp, current_season,
+            #                                                                 patrol_type)
+            final_patrols, final_romance_patrols = self.get_filtered_patrols(possible_patrols, biome, current_season,
                                                                             patrol_type)
             
 

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -1709,6 +1709,20 @@ class TalkScreen(Screens):
                 self.cat_dict["y_k"] = str(kit.name)
                 text = text.replace("y_k", str(kit.name))
 
+        # Your kit-- kitten age
+        if "y_kk" in text:
+            if "y_kk" in self.cat_dict:
+                text = text.replace("y_kk", self.cat_dict["y_kk"])
+            else:
+                if you.inheritance.get_children() is None or len(you.inheritance.get_children()) == 0:
+                    return ""
+                kit = Cat.fetch_cat(choice(you.inheritance.get_children()))
+                if kit.moons >= 6 or kit.outside or kit.dead or kit.ID == cat.ID:
+                    return ""
+                self.cat_dict["y_kk"] = str(kit.name)
+                text = text.replace("y_kk", str(kit.name))
+       
+
         # Random cat
         if "r_c" in text:
             if "r_c" in self.cat_dict:

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -905,7 +905,7 @@ class TalkScreen(Screens):
                 if you.shunned == 0:
                     continue
             
-            if "both_shunned" in tags:
+            if "both_shunned" in tags or ("they_shunned" in tags and "you_shunned" in tags):
                 if cat.shunned == 0 or you.shunned == 0:
                     continue
 

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -661,6 +661,12 @@ class TalkScreen(Screens):
             if "they_grieving" in tags and "grief stricken" not in cat.illnesses and not cat.dead:
                 continue
 
+            if "they_recovering_from_birth" in tags and "recovering from birth" not in cat.injuries:
+                continue
+
+            if "you_recovering_from_birth" in tags and "recovering from birth" not in you.injuries:
+                continue
+
             if "you_not_kit" in tags and game.clan.your_cat.moons < 6:
                 continue
 


### PR DESCRIPTION
- Pronoun tagged dates + DF patrols
- Lots of meow errors for shunned/grieving/newborn/dead combinations
- New dialogue tags: y_kk, they_recovering_from_birth, you_recovering_from_birth
- Shunned apprentice tweaks
- Fixed exiled cats reviving being put back into the Clan
- Dead cat backstory cleanup