### PR TITLE
Fix for playing as faded cat bug.

### DIFF
--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -1437,6 +1437,8 @@ class DeathScreen(UIWindow):
         self.mediator_button.enable()
         if game.clan.your_cat.revives < 5:
             self.mediator_button2.enable()
+        if (game.clan.your_cat.dead_for >= game.config["fading"]["age_to_fade"]) and game.clan.your_cat.prevent_fading == False:
+            self.mediator_button2.disable()
         self.mediator_button3.enable()
 
     def process_event(self, event):


### PR DESCRIPTION
Quick fix to stop the game from allowing you to be reincarnated (don't remember the term off the top of my head it's 1:30am, shush) when you've already faded. 

For now it just disables the button when you've faded, can maybe make it fancier later on!