### PR TITLE
Verb tagging, deaf tags for they_newborn dialogue

### DIFF
--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -5158,7 +5158,7 @@
             "Look, I get it, kits your age are full of boundless energy and accidents can happen, I'm guessing you didn't mean to tear up those herbs, they're pretty fragile.",
             "['Am I going outside the camp? Is that safe?']",
             "Yes, whilst I'm here, it will be fine, besides, we're not going too far, I know exactly where to look.",
-            "[t_c quickly informs the guards and then picks you up by the scruff, {PRONOUN/t_c/poss} grip firm. As {PRONOUN/t_c/subject} walks, it's silent, not even the birds or trees dared to move. {PRONOUN/t_c/subject/CAP} eventually sits you down and {VERB/t_c/loom/looms} above you, {PRONOUN/t_c/poss} gaze full of love and worry.]",
+            "[t_c quickly informs the guards and then picks you up by the scruff, {PRONOUN/t_c/poss} grip firm. As {PRONOUN/t_c/subject} walks, it's silent, not even the birds or trees dared to move. {PRONOUN/t_c/subject/CAP} eventually {VERB/t_c/sit/sits} you down and {VERB/t_c/loom/looms} above you, {PRONOUN/t_c/poss} gaze full of love and worry.]",
             "Let me be clear, I don't want you in there without supervision, but it's done now. What we can do is learn from it and I trust that you will remember that. The medicine den can be a very dangerous place.",
             "[{PRONOUN/t_c/subject/CAP} nudges you forwards, {PRONOUN/t_c/poss} shadow cast over you to protect you from the sky. The two of you walk in silence once more.]",
             "The last thing I want is for you to get hurt. I love you, you're my kit. It's my job to protect you however, I can't always be there. What if you slipped? What if there was a poisonous herb?",

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -5158,7 +5158,7 @@
             "Look, I get it, kits your age are full of boundless energy and accidents can happen, I'm guessing you didn't mean to tear up those herbs, they're pretty fragile.",
             "['Am I going outside the camp? Is that safe?']",
             "Yes, whilst I'm here, it will be fine, besides, we're not going too far, I know exactly where to look.",
-            "[t_c quickly informs the guards and then picks you up by the scruff, {PRONOUN/t_c/poss} grip firm. As {PRONOUN/t_c/subject} walks, it's silent, not even the birds or trees dared to move. {PRONOUN/t_c/subject/CAP} eventually sits you down and loom above you, {PRONOUN/t_c/poss} gaze full of love and worry.]",
+            "[t_c quickly informs the guards and then picks you up by the scruff, {PRONOUN/t_c/poss} grip firm. As {PRONOUN/t_c/subject} walks, it's silent, not even the birds or trees dared to move. {PRONOUN/t_c/subject/CAP} eventually sits you down and {VERB/t_c/loom/looms} above you, {PRONOUN/t_c/poss} gaze full of love and worry.]",
             "Let me be clear, I don't want you in there without supervision, but it's done now. What we can do is learn from it and I trust that you will remember that. The medicine den can be a very dangerous place.",
             "[{PRONOUN/t_c/subject/CAP} nudges you forwards, {PRONOUN/t_c/poss} shadow cast over you to protect you from the sky. The two of you walk in silence once more.]",
             "The last thing I want is for you to get hurt. I love you, you're my kit. It's my job to protect you however, I can't always be there. What if you slipped? What if there was a poisonous herb?",

--- a/resources/dicts/lifegen_talk/insults.json
+++ b/resources/dicts/lifegen_talk/insults.json
@@ -1582,7 +1582,9 @@
         [
             "insult",
             "you_shunned",
-            "they_newborn"
+            "they_newborn",
+            "they_deaf",
+            "they_blind"
         ],
         [
             "[t_c spits at you, and t_p quickly returns, swiping you away from {PRONOUN/t_p/poss} precious kit.]"
@@ -2384,7 +2386,8 @@
             "they_newborn",
             "insult",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -2411,7 +2414,8 @@
             "you_shunned",
             "they_blind",
             "you_blind",
-            "they_newborn"
+            "they_newborn",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -2832,7 +2836,10 @@
         [
             "they_newborn",
             "you_newborn",
-            "insult"
+            "insult",
+            "they_deaf",
+            "they_blind",
+            "you_blind"
         ],
         [
             "[Since you can't insult just yet, you flop onto t_c with a ferocious hiss.]",
@@ -2943,7 +2950,10 @@
         [
             "you_newborn",
             "they_newborn",
-            "insult"
+            "insult",
+            "they_deaf",
+            "they_blind",
+            "you_blind"
         ],
         [
             "Grrr..."

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -3,7 +3,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -13,7 +14,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -23,7 +25,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -33,7 +36,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -43,7 +47,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -53,7 +58,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -63,7 +69,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -73,7 +80,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -83,7 +91,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -93,7 +102,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -103,7 +113,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -113,7 +124,8 @@
         [
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -137,7 +149,8 @@
             "Any",
             "assertive",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mroww...",
@@ -149,7 +162,8 @@
             "Any",
             "assertive",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meowmeowmeowmeowmeow!",
@@ -174,7 +188,8 @@
             "any",
             "introspective",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew!",
@@ -205,7 +220,8 @@
             "any",
             "introspective",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "[You're sat grooming yourself in the clearing.]",
@@ -219,7 +235,8 @@
             "any",
             "introspective",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?",
@@ -248,7 +265,8 @@
         [
             "any",
             "introspective",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mewww???",
@@ -322,7 +340,8 @@
             "Any",
             "silly",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOW!",
@@ -335,7 +354,8 @@
             "newborn",
             "brooding",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!",
@@ -347,7 +367,8 @@
             "newborn",
             "brooding",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grrr ...",
@@ -359,10 +380,11 @@
             "newborn",
             "brooding",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
-            "Hisssss ..."
+            "Hisssss..."
         ]
     ],
     "broodingnewborn_4": [
@@ -383,7 +405,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew mew.",
@@ -395,7 +418,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mreow?",
@@ -407,7 +431,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meep...",
@@ -432,7 +457,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MMMMAAAARRRRRWWOOOOO!",
@@ -444,7 +470,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meowel...",
@@ -469,7 +496,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Maow!",
@@ -481,18 +509,20 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow.",
-            "[Never did you think a kitten could say meow' so bluntly, but here you are.]"
+            "[Never did you think a kitten could say 'meow' so bluntly, but here you are.]"
         ]
     ],
     "stable_newborn_10": [
         [
             "Any",
             "stable",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mew wow ow.",
@@ -503,7 +533,8 @@
         [
             "Any",
             "stable",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Meow, me mow.",
@@ -515,7 +546,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... ... ...",
@@ -540,7 +572,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meep!",
@@ -553,7 +586,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mraow. Mew?",
@@ -581,7 +615,8 @@
             "newborn",
             "littermate",
             "stable",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mehehe mew.",
@@ -594,7 +629,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MEOW!",
@@ -649,7 +685,8 @@
             "newborn",
             "unabashed",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew! Meoow! Mrrrrow!",
@@ -672,7 +709,8 @@
         [
             "Any",
             "cool",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "[t_c mewls in response to you saying {PRONOUN/t_c/poss} name.]",
@@ -697,7 +735,8 @@
             "upstanding",
             "queen's_apprentice",
             "queen",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "MEEEEW!",
@@ -709,7 +748,8 @@
             "upstanding",
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROW!",
@@ -732,7 +772,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Squeak!"
@@ -742,7 +783,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Eep!",
@@ -753,7 +795,8 @@
         [
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!",
@@ -793,7 +836,8 @@
             "from_your_kit",
             "from_adopted_kit",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "[t_c squirms at your side, mewling frantically.]",
@@ -861,7 +905,8 @@
             "unlawful",
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Squeak!",
@@ -873,7 +918,8 @@
             "unlawful",
             "Any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "[What's this newborn doing outside of the nursery?]",
@@ -936,7 +982,8 @@
             "Any",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... ... ...",
@@ -1037,7 +1084,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meep!",
@@ -1050,7 +1098,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mraow. Mew?",
@@ -1078,7 +1127,8 @@
             "newborn",
             "littermate",
             "stable",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mehehe mew.",
@@ -1091,7 +1141,8 @@
             "littermate",
             "stable",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MEOW!",
@@ -1171,7 +1222,8 @@
             "Any",
             "sweet",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "[You're not having a good day, sighing as you lay down on a rock close to the nursery.]",
@@ -1211,7 +1263,8 @@
             "upstanding",
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROW!",
@@ -1325,7 +1378,8 @@
             "they_sc",
             "you_sc",
             "Any",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "[You find yourself wandering close to the Dark Forest border when you spot movement out of the corner of your eye.]",
@@ -1389,7 +1443,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1401,7 +1456,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1413,7 +1469,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1425,7 +1482,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1437,7 +1495,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1449,7 +1508,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1461,7 +1521,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1473,7 +1534,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1485,7 +1547,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1497,7 +1560,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1509,7 +1573,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1521,7 +1586,8 @@
             "they_df",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1532,7 +1598,8 @@
             "Any",
             "they_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1544,7 +1611,8 @@
             "they_df",
             "you_shunned",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1556,7 +1624,8 @@
             "they_sc",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1568,7 +1637,8 @@
             "they_sc",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1580,7 +1650,8 @@
             "they_sc",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1592,7 +1663,8 @@
             "they_sc",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1604,7 +1676,8 @@
             "they_sc",
             "you_df",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1616,7 +1689,8 @@
             "they_sc",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1628,7 +1702,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1640,7 +1715,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1652,7 +1728,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1664,7 +1741,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1676,7 +1754,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1688,7 +1767,8 @@
             "they_df",
             "you_sc",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1699,7 +1779,8 @@
             "they_ur",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... Mew..."
@@ -1711,7 +1792,8 @@
             "you_sc",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... Mew..."
@@ -1723,7 +1805,8 @@
             "you_df",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... Mew..."
@@ -1735,7 +1818,8 @@
             "you_shunned",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "... Mew..."
@@ -1748,7 +1832,8 @@
             "you_sc",
             "any",
             "you_blind",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mew!",
@@ -1762,7 +1847,8 @@
             "you_df",
             "any",
             "you_blind",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "Mewwww...",
@@ -1775,7 +1861,8 @@
             "you_ur",
             "they_ur",
             "they_newborn",
-            "they_blind"
+            "they_blind",
+            "they_deaf"
         ],
         [
             "[You see t_c rolling in the misty fields, the tiny kitten angrily flopping around.]",
@@ -1791,7 +1878,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1804,7 +1892,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1817,7 +1906,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1830,7 +1920,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1843,7 +1934,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1856,7 +1948,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1869,7 +1962,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1882,7 +1976,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1895,7 +1990,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1908,7 +2004,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1921,7 +2018,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -1934,7 +2032,8 @@
             "they_dead",
             "they_outside",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Grr..."
@@ -1945,7 +2044,8 @@
             "Any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -1956,7 +2056,8 @@
             "Any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Meow!"
@@ -1967,7 +2068,8 @@
             "Any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -1978,7 +2080,8 @@
             "Any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -1989,7 +2092,8 @@
             "Any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -2001,7 +2105,8 @@
             "they_dead",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew?"
@@ -2026,7 +2131,8 @@
             "they_dead",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purrrrr..."
@@ -2038,7 +2144,8 @@
             "they_dead",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrow!"
@@ -2050,7 +2157,8 @@
             "they_dead",
             "any",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "MROOOOOOOOW!!!!!!!!"
@@ -2063,7 +2171,8 @@
             "you_shunned",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purr......"
@@ -2075,7 +2184,8 @@
             "any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Purr......"
@@ -2087,7 +2197,8 @@
             "you_dead",
             "newborn",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mrrp?"
@@ -2154,7 +2265,8 @@
             "any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew? Mew? ... Mew?"
@@ -2166,7 +2278,8 @@
             "any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew? Mew? ... Mew?"
@@ -2178,7 +2291,8 @@
             "any",
             "they_dead",
             "they_blind",
-            "you_blind"
+            "you_blind",
+            "they_deaf"
         ],
         [
             "Mew? Mew? ... Mew?"


### PR DESCRIPTION
* Verb tags for a general_you_kit dialogue
* Tagged most they_newborn dialogue/insults to be deaf-compatible, to (hopefully) reduce errors with newborn dialogue/insults. It does include some with "speaking," but to paraphrase what I said in Discord: even when the cats are unaware of the newborn's conditions, the "speech" is almost always just the newborn making a noise, and we have existing dialogue mentioning deaf kits who are unaware of how loud they are, so it seems like it'd fit as-is.