### PR TITLE
Bug Fixes

### DIFF
--- a/resources/dicts/patrols/lifegen/date.json
+++ b/resources/dicts/patrols/lifegen/date.json
@@ -764,7 +764,7 @@
         ],
         "success_outcomes": [
             {
-                "text": "You nervously ask r_c and {PRONOUN/r_c/subject} look away, blushing a bit. {PRONOUN/r_c/subject/CAP} purr and tell you to just focus on the sky, though you can't help but notice {PRONOUN/r_c/object} glancing at you affectionately every now and then.",
+                "text": "You nervously ask r_c and {PRONOUN/r_c/subject} look away, blushing a bit. {PRONOUN/r_c/subject/CAP} {VERB/r_c/purr/purrs} and tell you to just focus on the sky, though you can't help but notice {PRONOUN/r_c/object} glancing at you affectionately every now and then.",
                 "exp": 0,
                 "weight": 20,
                 "relationships": [

--- a/scripts/cat/skills.py
+++ b/scripts/cat/skills.py
@@ -442,12 +442,18 @@ class Skill:
         """Gets the string that is saved in the cat data"""
         return f"{self.path.name},{self.points},{self.interest_only}"
     
-    def get_skill_from_string(self, string):
+    def get_skill_from_string(self, string, interest=False):
         """Returns a SkillPath given a string skill"""
+
+        # LG
+        if interest:
+            interest_string = "True"
+        else:
+            interest_string = "False"
         for skill in SkillPath:
             if string in skill.value:
                 index = skill.value.index(string)
-                return self.generate_from_save_string(f"{skill.name},{Skill.get_points_to_tier(self, tier=max(1,index))},False")
+                return self.generate_from_save_string(f"{skill.name},{Skill.get_points_to_tier(self, tier=max(1,index))},{interest_string}")
             
         return "String not found in any Enum"
 

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -11,7 +11,7 @@ from scripts.cat_relations.interaction import (
 )
 from scripts.event_class import Single_Event
 from scripts.game_structure.game_essentials import game
-from scripts.utility import get_personality_compatibility, process_text
+from scripts.utility import get_personality_compatibility, process_text, event_text_adjust
 
 
 # ---------------------------------------------------------------------------- #
@@ -241,7 +241,13 @@ class Relationship:
             "r_c": (str(self.cat_to.name), choice(self.cat_to.pronouns)),
         }
 
-        return process_text(string, cat_dict)
+        # LG: added o_c_n and c_n
+        event_text = process_text(string, cat_dict)
+        if game.clan.all_clans:
+            event_text = event_text.replace("o_c_n", random.choice(game.clan.all_clans).name + "Clan")
+        event_text = event_text.replace("c_n", game.clan.name + "Clan")
+
+        return event_text
 
     def get_amount(self, in_de_crease: str, intensity: str) -> int:
         """Calculates the amount of such an interaction.

--- a/scripts/game_structure/windows.py
+++ b/scripts/game_structure/windows.py
@@ -698,7 +698,7 @@ class PronounCreation(UIWindow):
             f"Create new pronouns,"
             f" you have full control. "
             f"<br> Test your created pronouns before saving them!",
-            ui_scale(pygame.Rect((15, 60), (380, 75))),
+            ui_scale(pygame.Rect((15, 50), (380, 75))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -720,7 +720,7 @@ class PronounCreation(UIWindow):
         # Title of Demo Box
         self.elements["demo title"] = pygame_gui.elements.UITextBox(
             "<b>Demo",
-            ui_scale(pygame.Rect((75, 15), (225, 32))),
+            ui_scale(pygame.Rect((75, 10), (225, 32))),
             object_id="#text_box_34_horizleft",
             manager=MANAGER,
             container=self.demo_container,
@@ -729,7 +729,7 @@ class PronounCreation(UIWindow):
         # Add UITextBox for the sample text to the sub-container
         self.sample_text_box = pygame_gui.elements.UITextBox(
             self.get_sample_text(self.the_cat.pronouns[0]),
-            ui_scale(pygame.Rect((7, 60), (197, 278))),
+            ui_scale(pygame.Rect((7, 30), (197, 278))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self.demo_container,
@@ -754,7 +754,7 @@ class PronounCreation(UIWindow):
         # Adjusted positions for labels
         self.box_labels["subject"] = pygame_gui.elements.UITextBox(
             "Subject",
-            ui_scale(pygame.Rect((87, 115), (100, 30))),
+            ui_scale(pygame.Rect((87, 100), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -762,7 +762,7 @@ class PronounCreation(UIWindow):
 
         self.box_labels["object"] = pygame_gui.elements.UITextBox(
             "Object",
-            ui_scale(pygame.Rect((212, 115), (100, 30))),
+            ui_scale(pygame.Rect((212, 100), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -770,7 +770,7 @@ class PronounCreation(UIWindow):
 
         self.box_labels["poss"] = pygame_gui.elements.UITextBox(
             "Possessive",
-            ui_scale(pygame.Rect((25, 205), (100, 30))),
+            ui_scale(pygame.Rect((25, 170), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -778,7 +778,7 @@ class PronounCreation(UIWindow):
 
         self.box_labels["inposs"] = pygame_gui.elements.UITextBox(
             "Independent<br>Possessive",
-            ui_scale(pygame.Rect((125, 185), (150, 60))),
+            ui_scale(pygame.Rect((125, 150), (150, 60))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -786,7 +786,7 @@ class PronounCreation(UIWindow):
 
         self.box_labels["self"] = pygame_gui.elements.UITextBox(
             "Reflexive",
-            ui_scale(pygame.Rect((275, 205), (100, 30))),
+            ui_scale(pygame.Rect((275, 170), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -794,7 +794,7 @@ class PronounCreation(UIWindow):
         
         self.box_labels["parent"] = pygame_gui.elements.UITextBox(
             "Parent",
-            ui_scale(pygame.Rect((175, 460), (200, 60))),
+            ui_scale(pygame.Rect((87, 235), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -802,7 +802,7 @@ class PronounCreation(UIWindow):
 
         self.box_labels["sibling"] = pygame_gui.elements.UITextBox(
             "Sibling",
-            ui_scale(pygame.Rect((425, 460), (200, 60))),
+            ui_scale(pygame.Rect((215, 235), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -810,14 +810,14 @@ class PronounCreation(UIWindow):
 
         self.checkbox_label["singular_label"] = pygame_gui.elements.UITextBox(
             "Singular",
-            ui_scale(pygame.Rect((128, 285), (100, 30))),
+            ui_scale(pygame.Rect((60, 350), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
         )
         self.checkbox_label["plural_label"] = pygame_gui.elements.UITextBox(
             "Plural",
-            ui_scale(pygame.Rect((235, 285), (100, 30))),
+            ui_scale(pygame.Rect((180, 350), (100, 30))),
             object_id="#text_box_30_horizcenter_spacing_95",
             manager=MANAGER,
             container=self,
@@ -825,14 +825,14 @@ class PronounCreation(UIWindow):
 
         # Row 1
         self.boxes["subject"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((90, 145), (100, 30))),
+            ui_scale(pygame.Rect((90, 125), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["subject"],
             manager=MANAGER,
             container=self,
         )
 
         self.boxes["object"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((215, 145), (100, 30))),
+            ui_scale(pygame.Rect((215, 125), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["object"],
             manager=MANAGER,
             container=self,
@@ -840,35 +840,35 @@ class PronounCreation(UIWindow):
 
         # Row 2
         self.boxes["poss"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((25, 235), (100, 30))),
+            ui_scale(pygame.Rect((25, 200), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["poss"],
             manager=MANAGER,
             container=self,
         )
 
         self.boxes["inposs"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((150, 235), (100, 30))),
+            ui_scale(pygame.Rect((150, 200), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["inposs"],
             manager=MANAGER,
             container=self,
         )
 
         self.boxes["self"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((275, 235), (100, 30))),
+            ui_scale(pygame.Rect((275, 200), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["self"],
             manager=MANAGER,
             container=self,
         )
 
         self.boxes["parent"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((180, 520), (200, 60))),
+            ui_scale(pygame.Rect((90, 275), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["parent"],
             manager=MANAGER,
             container=self,
         )
 
         self.boxes["sibling"] = pygame_gui.elements.UITextEntryLine(
-            ui_scale(pygame.Rect((430, 520), (200, 60))),
+            ui_scale(pygame.Rect((215, 275), (100, 30))),
             placeholder_text=self.the_cat.pronouns[0]["sibling"],
             manager=MANAGER,
             container=self,
@@ -892,7 +892,7 @@ class PronounCreation(UIWindow):
         # Add buttons
         self.buttons = {}
         self.buttons["save_pronouns"] = UISurfaceImageButton(
-            ui_scale(pygame.Rect((0, 335), (73, 30))),
+            ui_scale(pygame.Rect((140, 345), (73, 30))),
             "save",
             get_button_dict(ButtonStyles.SQUOVAL, (73, 30)),
             object_id="@buttonstyles_squoval",
@@ -902,7 +902,7 @@ class PronounCreation(UIWindow):
         )
         # Creating Checkmarks
         self.buttons["singular_unchecked"] = UIImageButton(
-            ui_scale(pygame.Rect((112, 285), (34, 34))),
+            ui_scale(pygame.Rect((40, 350), (34, 34))),
             "",
             object_id="@unchecked_checkbox",
             starting_height=2,
@@ -911,7 +911,7 @@ class PronounCreation(UIWindow):
             container=self,
         )
         self.buttons["singular_checked"] = UIImageButton(
-            ui_scale(pygame.Rect((112, 285), (34, 34))),
+            ui_scale(pygame.Rect((40, 350), (34, 34))),
             "",
             object_id="@checked_checkbox",
             starting_height=2,
@@ -921,7 +921,7 @@ class PronounCreation(UIWindow):
         )
 
         self.buttons["plural_unchecked"] = UIImageButton(
-            ui_scale(pygame.Rect((227, 285), (34, 34))),
+            ui_scale(pygame.Rect((165, 350), (34, 34))),
             "",
             object_id="@unchecked_checkbox",
             starting_height=2,
@@ -930,7 +930,7 @@ class PronounCreation(UIWindow):
             container=self,
         )
         self.buttons["plural_checked"] = UIImageButton(
-            ui_scale(pygame.Rect((227, 285), (34, 34))),
+            ui_scale(pygame.Rect((165, 350), (34, 34))),
             "",
             object_id="@checked_checkbox",
             starting_height=2,
@@ -1056,7 +1056,7 @@ class PronounCreation(UIWindow):
                 self.sample_text_box.kill()
                 self.sample_text_box = pygame_gui.elements.UITextBox(
                     self.get_sample_text(self.get_new_pronouns()),
-                    ui_scale(pygame.Rect((7, 60), (197, 278))),
+                    ui_scale(pygame.Rect((7, 30), (197, 278))),
                     object_id="#text_box_30_horizcenter_spacing_95",
                     manager=MANAGER,
                     container=self.demo_container,

--- a/scripts/screens/AffairScreen.py
+++ b/scripts/screens/AffairScreen.py
@@ -149,6 +149,7 @@ class AffairScreen(Screens):
         self.update_cat_list()
 
     def exit_screen(self):
+        self.current_page = 1
 
         for ele in self.cat_list_buttons:
             self.cat_list_buttons[ele].kill()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2965,6 +2965,9 @@ class MakeClanScreen(Screens):
                     y_pos += 40
 
             y_pos = 0
+            traits = []
+            for trait in Personality.trait_ranges["kit_traits"]:
+                traits.append(trait)
             traits = ['troublesome', 'lonesome', 'impulsive', 'bullying', 'attention-seeker', 'charming', 'daring', 'noisy', 'nervous', 'quiet', 'insecure', 'daydreamer', 'sweet', 'polite', 'know-it-all', 'bossy', 'disciplined', 'patient', 'manipulative', 'secretive', 'rebellious', 'grumpy', 'passionate', 'honest', 'leader-like', 'smug']
             if self.current_selection == "trait":
                 for trait in traits:
@@ -3734,7 +3737,7 @@ class MakeClanScreen(Screens):
                 self.your_cat.personality = Personality(trait=self.personality, kit_trait=True)
                 if self.skill == "Random":
                     self.skill = random.choice(self.skills)
-                self.your_cat.skills.primary = Skill.get_skill_from_string(Skill, self.skill)
+                self.your_cat.skills.primary = Skill.get_skill_from_string(Skill, self.skill, "True")
                 self.your_cat.lock_faith = self.faith
                 self.selected_cat = None
                 self.open_name_cat()

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -2065,6 +2065,10 @@ class MakeClanScreen(Screens):
 
         self.clear_all_page()
         self.sub_screen = "customize cat"
+
+        self.selected_cat = None
+        # clearing selected cat for the eye colour display bug
+
         pelt2 = Pelt(
             name=self.pname,
             length=self.length,

--- a/scripts/screens/MurderScreen.py
+++ b/scripts/screens/MurderScreen.py
@@ -1149,8 +1149,8 @@ class MurderScreen(Screens):
                 print("Discovery chances will go up if the leader doesn't lose all of their lives.")
 
     def change_cat(self, new_mentor=None, accomplice=None, accompliced=None):
+        self.current_page = 1
         self.exit_screen()
-        self.current_page = 0
         r = randint(0,100)
         r2 = randint(-10, 10)
 


### PR DESCRIPTION
- Fixed customiser eye colours all displaying the same text when opening the customiser after selecting a rolled kit
- Fixed customised MC skills "interest" value being False
- Fixed some adult traits being present in the customiser trait pool
- Fixed pronoun creation window to add parent/sibling pronouns back
- added o_c_n and c_n text replacements to relationship events
- reset cat pages on affair and murder screens-- leaving the page num too high then returning to the screen after losing a page would crash with an indexerror