### PR TITLE
Additional quick fix to the clan creation names

### DIFF
--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -579,7 +579,7 @@ class MakeClanScreen(Screens):
                 return
             self.your_cat.name.prefix = new_name
 
-            while self.your_cat.name.prefix == self.your_cat.name.suffix:
+            while self.your_cat.name.prefix.lower() == self.your_cat.name.suffix:
                 print("Prefix and suffix are the same, rerolling suffix...")
                 self.your_cat.name.give_suffix(self.your_cat.pelt, game.clan.biome, None)
 


### PR DESCRIPTION
Forgot to add a line that makes sure it checks the prefix is in lowercase, because people are probably gonna be typing in either Camelcase or some abomination that I can't fully mentally comprehend with eepy cheeb brain