### PR TITLE
Dialogue Bugfixes

### DIFF
--- a/resources/dicts/lifegen_talk/apprentice.json
+++ b/resources/dicts/lifegen_talk/apprentice.json
@@ -7905,5 +7905,49 @@
            "Why does everycat act like learning the warrior code is some kind of huge chore? I memorized it right after I became an apprentice.",
            "It's the rules that guide our lives! They're not hard to remember if you live by them!"
         ]
+    },
+    "multichar_J6": {
+        "y_c": {
+            "status": ["apprentice"],
+            "condition": ["blind:any:false"]
+        },
+        "t_c": {
+            "status": ["apprentice"],
+            "cluster": [
+                "brooding", "unlawful", "cool", "assertive"
+            ],
+            "condition": ["blind:any:false"]
+        },
+        "relationship": ["max_platonic_10"],
+        "intro": [
+            "[After a group training session, t_c is sharing tongues with neutral-r_a. You wander up to the two to try and join the conversation.]",
+            "... tm_n was in such a bad mood today. Don't you think I deserved more praise than what {PRONOUN/tm_n/subject} gave me?",
+            "|neutral-r_a|Yeah, maybe that's true...",
+            "It's definitely true. I was practically--",
+            "Um. Hi, y_c. Can I help you?"
+        ],
+        "intro_choices": {
+            "choice1": {
+                "text": "Nevermind",
+                "next_scene": "nevermind"
+            },
+            "choice2": {
+                "text": "Join them",
+                "next_scene": "jointhem"
+            }
+        },
+        "nevermind": [
+            "Okay... heh.",
+            "Can you leave, then? You're blocking the sun."
+        ],
+        "jointhem": [
+            "I don't think there's any room for you... and we're almost finished with this rabbit, so...",
+            "|neutral-r_a|No, no, you can sit, y_c! I can't finish this leg. Here.",
+            "[neutral-r_a nudges a rabbit leg in your direction as you sit down. You thank {PRONOUN/neutral-r_a/object}.]",
+            "[Before you can take a bite, t_c abruptly stands up.]",
+            "Take mine, too. I'm full.",
+            "[t_c stalks away, tail twitching. Did you do something wrong..?]",
+            "|neutral-r_a|Don't worry about {PRONOUN/t_c/object}. Bad training day."
+        ]
     }
 }

--- a/resources/dicts/lifegen_talk/apprentice.json
+++ b/resources/dicts/lifegen_talk/apprentice.json
@@ -7905,49 +7905,5 @@
            "Why does everycat act like learning the warrior code is some kind of huge chore? I memorized it right after I became an apprentice.",
            "It's the rules that guide our lives! They're not hard to remember if you live by them!"
         ]
-    },
-    "multichar_J6": {
-        "y_c": {
-            "status": ["apprentice"],
-            "condition": ["blind:any:false"]
-        },
-        "t_c": {
-            "status": ["apprentice"],
-            "cluster": [
-                "brooding", "unlawful", "cool", "assertive"
-            ],
-            "condition": ["blind:any:false"]
-        },
-        "relationship": ["max_platonic_10"],
-        "intro": [
-            "[After a group training session, t_c is sharing tongues with neutral-r_a. You wander up to the two to try and join the conversation.]",
-            "... tm_n was in such a bad mood today. Don't you think I deserved more praise than what {PRONOUN/tm_n/subject} gave me?",
-            "|neutral-r_a|Yeah, maybe that's true...",
-            "It's definitely true. I was practically--",
-            "Um. Hi, y_c. Can I help you?"
-        ],
-        "intro_choices": {
-            "choice1": {
-                "text": "Nevermind",
-                "next_scene": "nevermind"
-            },
-            "choice2": {
-                "text": "Join them",
-                "next_scene": "jointhem"
-            }
-        },
-        "nevermind": [
-            "Okay... heh.",
-            "Can you leave, then? You're blocking the sun."
-        ],
-        "jointhem": [
-            "I don't think there's any room for you... and we're almost finished with this rabbit, so...",
-            "|neutral-r_a|No, no, you can sit, y_c! I can't finish this leg. Here.",
-            "[neutral-r_a nudges a rabbit leg in your direction as you sit down. You thank {PRONOUN/neutral-r_a/object}.]",
-            "[Before you can take a bite, t_c abruptly stands up.]",
-            "Take mine, too. I'm full.",
-            "[t_c stalks away, tail twitching. Did you do something wrong..?]",
-            "|neutral-r_a|Don't worry about {PRONOUN/t_c/object}. Bad training day."
-        ]
     }
 }

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -3625,11 +3625,11 @@
                 "introspective"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3650,11 +3650,11 @@
                 "upstanding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3673,11 +3673,11 @@
                 "introspective"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3697,11 +3697,11 @@
                 "upstanding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3722,11 +3722,11 @@
                 "upstanding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3745,11 +3745,11 @@
                 "brooding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3767,11 +3767,11 @@
                 "neurotic"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3790,11 +3790,11 @@
                 "unlawful"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3814,11 +3814,11 @@
                 "silly"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3837,11 +3837,11 @@
                 "cool"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3860,11 +3860,11 @@
                 "brooding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3884,11 +3884,11 @@
                 "introspective"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3908,11 +3908,11 @@
                 "upstanding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3932,11 +3932,11 @@
                 "upstanding"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3956,11 +3956,11 @@
                 "neurotic"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3980,11 +3980,11 @@
                 "neurotic"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ]
         },
         "tags": [
-            "heartbroken",
             "accept"
         ],
         "intro": [
@@ -3994,14 +3994,12 @@
     "flirt_sh_J25": {
         "y_c": {
             "condition": [
-                "blind:any:false",
                 "blind:any:false"
             ],
             "shunned": true
         },
         "t_c": {
             "condition": [
-                "blind:any:false",
                 "blind:any:false"
             ]
         },
@@ -5617,12 +5615,12 @@
         },
         "t_c": {
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "heartbroken"
             ],
             "shunned": true
         },
         "tags": [
-            "heartbroken",
             "reject"
         ],
         "intro": [
@@ -6050,11 +6048,19 @@
         ]
     },
     "flirt_reject_H14": {
-        "y_c": {},
-        "t_c": {},
+        "y_c": {
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "blind:any:false",
+                "heartbroken"
+            ],
+            "shunned": "any"
+        },
         "tags": [
-            "reject",
-            "heartbroken"
+            "reject"
         ],
         "intro": [
             "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -45502,6 +45502,4 @@
             "Things have fallen behind enough already without my help."
         ]
     }
-
-
 }

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -35399,7 +35399,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -35424,7 +35424,7 @@
                 9
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -35442,7 +35442,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -35464,7 +35464,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -35489,7 +35489,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -35512,7 +35512,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -5199,19 +5199,19 @@
     "no_newborn_brooding_SQ1": {
         "season": ["newleaf", "greenleaf"],
         "t_c": {
-"status": ["not_kitten"],
+            "status": ["not_kitten"],
             "cluster": ["brooding"],
             "skill": ["ARTISTAN,1"]
-},
+        },
         "relationship": ["max_platonic_30"],
         "intro": [
             "[There are new flowers decorating the warriors' den! You walk over to inspect them, but hear t_c snap from behind you.]",
             "Don't touch those flowers, y_c. I've spent ages arranging them.",
             "[t_c narrows {PRONOUN/t_c/poss} eyes at you until you back away from {PRONOUN/t_c/poss} precious decoration.]"
-]
-},
+        ]
+    },
 
- "no_newborn_brooding_SQ2": {
+    "no_newborn_brooding_SQ2": {
         "y_c": {
             "condition": ["blind:any:false"]
         },
@@ -5219,12 +5219,11 @@
             "status": ["not_kitten"],
             "cluster": ["brooding"],
             "condition": ["blind:any:false"]
-},
+        },
         "relationship": ["max_platonic_30"],
         "intro": [
             "I can't help you right now. Ask neutral-r_w or somecat.",
             "...No, I'm not busy. I just want to spend some time alone."
-]
-}
-
+        ]
+    }
 }

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -4519,7 +4519,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [
@@ -4634,7 +4634,7 @@
                 "max_they_deadfor_5"
             ]
         },
-        "tags": [
+        "relationship": [
             "murderedthem"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -16951,13 +16951,12 @@
             "status": ["kitten"],
             "cluster": ["upstanding"],
             "condition": ["illness:any", "injury:any"]
-},
+        },
         "relationship": ["max_dislike_5"],
         "intro": [
            "[t_c turns away when you begin inviting {PRONOUN/t_c/object} to play.]",
            "I'm s'posed to rest so I get better. r_m's orders.",
            "No, don't argue! You've gotta leave me alone now."
-]
-}
-
+        ]
+    }
 }

--- a/resources/dicts/lifegen_talk/leader.json
+++ b/resources/dicts/lifegen_talk/leader.json
@@ -4683,5 +4683,4 @@
             "[Yeah... You're definitely keeping t_c in the medicine den. d_n can take over leading the clan until t_c is better.]"
         ]
     }
-
 }

--- a/resources/dicts/lifegen_talk/mediator apprentice.json
+++ b/resources/dicts/lifegen_talk/mediator apprentice.json
@@ -2271,7 +2271,8 @@
             ]
         },
         "intro": [
-            "[The mediator apprentice has been walking around all day in some sort of disguise, decorating {PRONOUN/t_c/self} in leaves and twigs that seem to have at least some rhyme or reason. Intrigued, you come up to {PRONOUN/t_c/object} to ask why {PRONOUN/t_c/subject}{VERB/t_c/'ve/'s} decorated {PRONOUN/t_c/poss} pelt today.]",
+            "[The mediator apprentice has been walking around all day in some sort of disguise, decorating {PRONOUN/t_c/self} in leaves and twigs that seem to have at least some rhyme or reason.]",
+            "[Intrigued, you come up to {PRONOUN/t_c/object} to ask why {PRONOUN/t_c/subject}{VERB/t_c/'ve/'s} decorated {PRONOUN/t_c/poss} pelt today.]",
             "Oh! Well, y_c, r_c was feeling down, so I wanted to cheer {PRONOUN/r_c/object} up by dressing myself up!",
             "{PRONOUN/r_c/subject/CAP} told somecat else about... uh...",
             "...Nevermind, I can't say that! I refuse to admit that I'm nosy! Bye, y_c!",

--- a/resources/dicts/lifegen_talk/mediator apprentice.json
+++ b/resources/dicts/lifegen_talk/mediator apprentice.json
@@ -2596,17 +2596,17 @@
         ]
     },
     "sevhache_sam1": {
-            "y_c": {
-                "status": ["not_kitten"],
-                "condition": ["blind:any:false"]
-            },
-            "t_c": {
-                "condition": ["severe headache", "blind:any:false"],
-                "status": ["mediator", "mediator apprentice"]
-            },
-            "intro": [
-                "Ugh... My headache is messing with my ability to mediate arguments.",
-                "How have I never noticed how loud arguments are?"
-            ]
-        }
+        "y_c": {
+            "status": ["not_kitten"],
+            "condition": ["blind:any:false"]
+        },
+        "t_c": {
+            "condition": ["severe headache", "blind:any:false"],
+            "status": ["mediator", "mediator apprentice"]
+        },
+        "intro": [
+            "Ugh... My headache is messing with my ability to mediate arguments.",
+            "How have I never noticed how loud arguments are?"
+        ]
+    }
 }

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -1199,7 +1199,10 @@ class TalkScreen(Screens):
             # ---
 
             if "war" in TAGS:
-                if game.clan.war.get("at_war", False):
+                if "at_war" in game.clan.war:
+                    if not game.clan.war["at_war"]:
+                        continue
+                else:
                     continue
 
             if "clan_has_kits" in TAGS:
@@ -1502,12 +1505,20 @@ class TalkScreen(Screens):
         if "not_kitten" in BLOCK["age"] and cat.status == "newborn":
             return False
 
-        if "younger" in BLOCK["age"] and not (cat.moons < game.clan.your_cat.moons):
-            return False
-        if "sameage" in BLOCK["age"] and not (cat.age == game.clan.your_cat.age):
-            return False
-        if "older" in BLOCK["age"] and not (cat.moons > game.clan.your_cat.moons):
-            return False
+        if cat == game.clan.your_cat:
+            if "younger" in BLOCK["age"] and cat.moons >= self.the_cat.moons:
+                return False
+            if "sameage" in BLOCK["age"] and cat.age != self.the_cat.age:
+                return False
+            if "older" in BLOCK["age"] and cat.moons <= self.the_cat.moons:
+                return False
+        else:
+            if "younger" in BLOCK["age"] and cat.moons >= game.clan.your_cat.moons:
+                return False
+            if "sameage" in BLOCK["age"] and cat.age != game.clan.your_cat.age:
+                return False
+            if "older" in BLOCK["age"] and cat.moons <= game.clan.your_cat.moons:
+                return False
 
         if any(st in [
             "newborn", "kitten", "adolescent", "young adult",

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -3903,6 +3903,12 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat in current_cat_objects
     ) else True
 
+    r_c_sc = False if (
+        not chosen_cat.dead or
+        chosen_cat.df or
+        chosen_cat.outside
+    ) else True
+
     # now the abbrevs dict!
     # make sure to add new abbrevs here, or they won't get replaced!!!
     abbrevs = {
@@ -3966,7 +3972,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         "e_c": e_c,
         "fc_c": fc_c,
         "tg_c": tg_c,
-        "yg_c": yg_c
+        "yg_c": yg_c,
+        "r_c_sc": r_c_sc
     }
 
     return abbrevs
@@ -4012,9 +4019,14 @@ def lifegen_text_adjust(Cat, text, cat, cat_dict, r_c_allowed, o_c_allowed):
                 continue
             if abbrev_string == "r_w" and "r_w1" in text:
                 continue
-            if abbrev_string == "t_k" and ("t_ka" in text or "t_kk" in text):
+            if abbrev_string == "t_k" and "t_ka" in text:
+                continue
+            if abbrev_string == "t_k" and "t_kk" in text:
                 continue
             if abbrev_string == "m_n" and "tm_n" in text:
+                continue
+
+            if abbrev_string == "r_c" and "r_c_sc" in text:
                 continue
 
             # find cluster and rel addons if theyre there

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -3277,7 +3277,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.ID in cat.mates or
         chosen_cat.ID in you.mates or
-        chosen_cat.age != you.age or
+        not chosen_cat.is_dateable(you) or
         len(you.mates) > 0 or
         chosen_cat.outside or
         chosen_cat.dead or
@@ -3288,15 +3288,15 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
 
     theircrush = False if (
         chosen_cat.ID == cat.ID or
-        chosen_cat.ID == cat.ID or
+        chosen_cat.ID == you.ID or
         chosen_cat.ID in cat.mates or
-        chosen_cat.ID in cat.mates or
-        chosen_cat.age != you.age or
+        chosen_cat.ID in you.mates or
+        not chosen_cat.is_dateable(cat) or
         len(cat.mates) > 0 or
         chosen_cat.outside or
         chosen_cat.dead or
         chosen_cat not in cat.relationships or
-        (chosen_cat in cat.relationships and cat.relationships[chosen_cat.ID].romantic_love < 20) or
+        (chosen_cat in cat.relationships and cat.relationships[chosen_cat.ID].romantic_love < 15) or
         chosen_cat in current_cat_objects
     ) else True
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -3267,6 +3267,11 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
 
     # heres AALLLL the conditions for certain abbrevs to be valid
 
+    current_cat_objects = []
+    for abbrev, cat_object in cat_dict.items():
+        current_cat_objects.append(cat_object)
+        # print("Already in cat dict:", cat_object.name)
+
     yourcrush = False if (
         chosen_cat.ID == you.ID or
         chosen_cat.ID == cat.ID or
@@ -3277,7 +3282,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.outside or
         chosen_cat.dead or
         chosen_cat not in you.relationships or
-        (chosen_cat in you.relationships and you.relationships[chosen_cat.ID].romantic_love < 20)
+        (chosen_cat in you.relationships and you.relationships[chosen_cat.ID].romantic_love < 20) or
+        chosen_cat in current_cat_objects
     ) else True
 
     theircrush = False if (
@@ -3290,7 +3296,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.outside or
         chosen_cat.dead or
         chosen_cat not in cat.relationships or
-        (chosen_cat in cat.relationships and cat.relationships[chosen_cat.ID].romantic_love < 20)
+        (chosen_cat in cat.relationships and cat.relationships[chosen_cat.ID].romantic_love < 20) or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random statuses
@@ -3302,7 +3309,9 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         "r_c1" in text or
         "r_c2" in text or
         "r_c3" in text or
-        "r_c4" in text
+        "r_c4" in text or
+        chosen_cat.moons < 6 or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_w = False if (
@@ -3310,7 +3319,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status != "warrior"
+        chosen_cat.status != "warrior" or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_k = False if (
@@ -3318,7 +3328,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status not in ["kitten", "newborn"]
+        chosen_cat.status not in ["kitten", "newborn"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_a = False if (
@@ -3326,7 +3337,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status != "apprentice"
+        chosen_cat.status != "apprentice" or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_m = False if (
@@ -3334,7 +3346,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status not in ["medicine cat", "medicine cat apprentice"]
+        chosen_cat.status not in ["medicine cat", "medicine cat apprentice"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_d = False if (
@@ -3342,7 +3355,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status not in ["mediator", "mediator apprentice"]
+        chosen_cat.status not in ["mediator", "mediator apprentice"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_q = False if (
@@ -3350,7 +3364,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status not in ["queen", "queen's apprentice"]
+        chosen_cat.status not in ["queen", "queen's apprentice"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     r_e = False if (
@@ -3358,7 +3373,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status != "elder"
+        chosen_cat.status != "elder" or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random statuses-- Shunned
@@ -3371,7 +3387,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         "r_c2" in text or
         "r_c3" in text or
         "r_c4" in text or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_w = False if (
@@ -3380,7 +3397,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "warrior" or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_k = False if (
@@ -3389,7 +3407,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status not in ["kitten", "newborn"] or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_a = False if (
@@ -3398,7 +3417,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "apprentice" or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_m = False if (
@@ -3407,7 +3427,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status not in ["medicine cat", "medicine cat apprentice"] or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_d = False if (
@@ -3416,7 +3437,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status not in ["mediator", "mediator apprentice"] or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_q = False if (
@@ -3425,7 +3447,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status not in ["queen", "queen's apprentice"] or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     rsh_e = False if (
@@ -3434,7 +3457,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "elder" or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random sick cat
@@ -3443,7 +3467,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        not chosen_cat.is_ill()
+        not chosen_cat.is_ill() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random injured cat
@@ -3452,7 +3477,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        not chosen_cat.is_injured()
+        not chosen_cat.is_injured() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random grieving cat
@@ -3461,7 +3487,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        "grief stricken" not in chosen_cat.illnesses
+        "grief stricken" not in chosen_cat.illnesses or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your sibling-- any age
@@ -3470,7 +3497,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in you.inheritance.get_siblings()
+        chosen_cat.ID not in you.inheritance.get_siblings() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your littermate
@@ -3480,7 +3508,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in you.inheritance.get_siblings() or
-        chosen_cat.moons != you.moons
+        chosen_cat.moons != you.moons or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their sibling-- any age
@@ -3489,7 +3518,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in cat.inheritance.get_siblings()
+        chosen_cat.ID not in cat.inheritance.get_siblings() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their littermate
@@ -3499,7 +3529,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in cat.inheritance.get_siblings() or
-        chosen_cat.moons != cat.moons
+        chosen_cat.moons != cat.moons or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your apprentice
@@ -3508,7 +3539,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in you.apprentice
+        chosen_cat.ID not in you.apprentice or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their apprentice
@@ -3517,7 +3549,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in cat.apprentice
+        chosen_cat.ID not in cat.apprentice or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your parent
@@ -3526,7 +3559,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in you.inheritance.get_parents()
+        chosen_cat.ID not in you.inheritance.get_parents() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their parent
@@ -3535,7 +3569,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in cat.inheritance.get_parents()
+        chosen_cat.ID not in cat.inheritance.get_parents() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your mate
@@ -3544,7 +3579,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in you.mates
+        chosen_cat.ID not in you.mates or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their mate
@@ -3553,7 +3589,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in cat.mates
+        chosen_cat.ID not in cat.mates or
+        chosen_cat in current_cat_objects
     ) else True
 
     # nr_1/2 -- Two cats who are potential mates
@@ -3564,7 +3601,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.outside or
         len(chosen_cat.mates) > 0 or
         chosen_cat.moons < 14 or
-        "n_r2" not in text
+        "n_r2" not in text or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Gather cat object for first n_r cat
@@ -3581,23 +3619,18 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.outside or
         len(chosen_cat.mates) > 0 or
         (n_r1_object and not chosen_cat.is_potential_mate(n_r1_object)) or
-        n_r1_object is None
+        n_r1_object is None or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random cats
-    # Gather objects for random cats so the same one isn't chosen twice
-    r_c_objects = {}
-    for i in cat_dict.items():
-        for num in range(0,4):
-            if i[0] == f"r_c{str(num)}":
-                r_c_objects[f"r_c{str(num)}"] = i[1]
-        break
     
     r_c1 = False if (
         chosen_cat.ID == you.ID or
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
-        chosen_cat.outside
+        chosen_cat.outside or
+        chosen_cat in current_cat_objects
     ) else True
     
     r_c2 = False if (
@@ -3605,7 +3638,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        "r_c1" in r_c_objects and chosen_cat in [r_c_objects["r_c1"]]
+        chosen_cat in current_cat_objects
     ) else True
     
     r_c3 = False if (
@@ -3613,8 +3646,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        "r_c1" in r_c_objects and chosen_cat in [r_c_objects["r_c1"]] or
-        "r_c2" in r_c_objects and chosen_cat in [r_c_objects["r_c2"]]
+        chosen_cat in current_cat_objects
     ) else True
     
     r_c4 = False if (
@@ -3622,17 +3654,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        "r_c1" in r_c_objects and chosen_cat in [r_c_objects["r_c1"]] or
-        "r_c2" in r_c_objects and chosen_cat in [r_c_objects["r_c2"]] or
-        "r_c3" in r_c_objects and chosen_cat in [r_c_objects["r_c3"]]
+        chosen_cat in current_cat_objects
     ) else True
-
-    r_w_objects = {}
-    for i in cat_dict.items():
-        for num in range(0,4):
-            if i[0] == f"r_w{str(num)}":
-                r_w_objects[f"r_w{str(num)}"] = i[1]
-        break
 
     # Random warriors
     r_w1 = False if (
@@ -3640,7 +3663,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.status != "warrior"
+        chosen_cat.status != "warrior" or
+        chosen_cat in current_cat_objects
     ) else True
     
     r_w2 = False if (
@@ -3649,7 +3673,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "warrior" or
-        "r_w1" in r_w_objects and chosen_cat in [r_w_objects["r_w1"]]
+        chosen_cat in current_cat_objects
     ) else True
     
     r_w3 = False if (
@@ -3658,8 +3682,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "warrior" or
-        "r_w1" in r_w_objects and chosen_cat in [r_w_objects["r_w1"]] or
-        "r_w2" in r_w_objects and chosen_cat in [r_w_objects["r_w2"]]
+        chosen_cat in current_cat_objects
     ) else True
     
     r_w4 = False if (
@@ -3668,9 +3691,7 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.status != "warrior" or
-        "r_w1" in r_w_objects and chosen_cat in [r_w_objects["r_w1"]] or
-        "r_w2" in r_w_objects and chosen_cat in [r_w_objects["r_w2"]] or
-        "r_w3" in r_w_objects and chosen_cat in [r_w_objects["r_w3"]]
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their kits
@@ -3680,7 +3701,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in cat.inheritance.get_children()
+        chosen_cat.ID not in cat.inheritance.get_children() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # kit age
@@ -3690,7 +3712,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in cat.inheritance.get_children() or
-        chosen_cat.moons > 5
+        chosen_cat.moons > 5 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # adult age
@@ -3700,7 +3723,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in cat.inheritance.get_children() or
-        chosen_cat.moons < 12
+        chosen_cat.moons < 12 or
+        chosen_cat in current_cat_objects
     ) else True
     
     # Your kits
@@ -3710,7 +3734,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID not in you.inheritance.get_children()
+        chosen_cat.ID not in you.inheritance.get_children() or
+        chosen_cat in current_cat_objects
     ) else True
 
     # kit age
@@ -3720,7 +3745,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in you.inheritance.get_children() or
-        chosen_cat.moons > 5
+        chosen_cat.moons > 5 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # adult age
@@ -3730,7 +3756,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID not in you.inheritance.get_children() or
-        chosen_cat.moons < 12
+        chosen_cat.moons < 12 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Mentors
@@ -3740,7 +3767,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         not chosen_cat.dead or
         not chosen_cat.df or
-        chosen_cat.ID != you.df_mentor
+        chosen_cat.ID != you.df_mentor or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their DF mentor
@@ -3749,7 +3777,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         not chosen_cat.dead or
         not chosen_cat.df or
-        chosen_cat.ID != cat.df_mentor
+        chosen_cat.ID != cat.df_mentor or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Your mentor
@@ -3758,7 +3787,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID != you.mentor
+        chosen_cat.ID != you.mentor or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Their mentor
@@ -3767,7 +3797,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID != cat.mentor
+        chosen_cat.ID != cat.mentor or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Leader
@@ -3776,7 +3807,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID != game.clan.leader
+        chosen_cat.ID != game.clan.leader.ID or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Deputy
@@ -3785,7 +3817,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         chosen_cat.outside or
-        chosen_cat.ID != game.clan.deputy
+        chosen_cat.ID != game.clan.deputy.ID or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Leader-- Shunned
@@ -3795,7 +3828,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID != game.clan.leader or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Deputy-- Shunned
@@ -3805,7 +3839,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         chosen_cat.outside or
         chosen_cat.ID != game.clan.deputy or
-        chosen_cat.shunned != 0
+        chosen_cat.shunned != 0 or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Dead cat
@@ -3814,7 +3849,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
     d_c = False if (
         chosen_cat.ID == you.ID or
         chosen_cat.ID == cat.ID or
-        not chosen_cat.dead
+        not chosen_cat.dead or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Random DF cat
@@ -3822,7 +3858,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == you.ID or
         chosen_cat.ID == cat.ID or
         not chosen_cat.dead or
-        not chosen_cat.df
+        not chosen_cat.df or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Lost cat
@@ -3831,7 +3868,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.ID == cat.ID or
         chosen_cat.dead or
         not chosen_cat.outside or
-        chosen_cat.status in ["rogue", "kittypet", "loner", "former Clancat"]
+        chosen_cat.status in ["rogue", "kittypet", "loner", "former Clancat"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Exiled cat
@@ -3841,7 +3879,8 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
         chosen_cat.dead or
         not chosen_cat.outside or
         chosen_cat.status == "exiled" or
-        not chosen_cat.exiled
+        not chosen_cat.exiled or
+        chosen_cat in current_cat_objects
     ) else True
 
     # Talk focus cat
@@ -3853,13 +3892,15 @@ def lifegen_abbrevs(Cat, text, you, cat, chosen_cat, cat_dict):
     tg_c = False if (
         "grief stricken" not in cat.illnesses or 
         "grief stricken" in cat.illnesses and "grief_cat" not in cat.illnesses["grief stricken"] or
-        chosen_cat.ID != cat.illnesses["grief stricken"]["grief_cat"]
+        chosen_cat.ID != cat.illnesses["grief stricken"]["grief_cat"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     yg_c = False if (
         "grief stricken" not in you.illnesses or 
         "grief stricken" in you.illnesses and "grief_cat" not in you.illnesses["grief stricken"] or
-        chosen_cat.ID != you.illnesses["grief stricken"]["grief_cat"]
+        chosen_cat.ID != you.illnesses["grief stricken"]["grief_cat"] or
+        chosen_cat in current_cat_objects
     ) else True
 
     # now the abbrevs dict!
@@ -4110,7 +4151,10 @@ def lifegen_text_adjust(Cat, text, cat, cat_dict, r_c_allowed, o_c_allowed):
                 text = re.sub(r'(?<!\/)o_c_n(?!\/)', str(other_clan.name) + "Clan", text)
     # Warring Clan
     if "w_cClan" in text:
-        if game.clan.war.get("at_war", False):
+        if "at_war" in game.clan.war:
+            if not game.clan.war["at_war"]:
+                return ""
+        else:
             return ""
         text = text.replace("w_c", str(game.clan.war["enemy"]))
 


### PR DESCRIPTION
- real way to ensure no two abbrevs pull the same cat in one piece of dialogue
- fixes for war tag/w_cClan text replace (idk why war.get wasnt working, but it wasnt)
- fixes age tag filtering
- added back r_c_sc
- y_k fix
- heartbroken tag fix
- moved "murderedthem" from tags to rel where it was misplaced