### PR TITLE
Fixing Dialogue

### DIFF
--- a/resources/dicts/lifegen_talk/apprentice.json
+++ b/resources/dicts/lifegen_talk/apprentice.json
@@ -1155,6 +1155,7 @@
                 "medicine cat apprentice",
                 "mediator apprentice",
                 "queen's apprentice",
+                "mediator",
                 "queen",
                 "elder"
             ],
@@ -1170,12 +1171,12 @@
                 "blind:any:false"
             ],
             "status": [
-                "apprentice"
+                "apprentice",
+                "warrior",
+                "deputy"
             ]
         },
-        "tags": [
-            "you_meditator"
-        ],
+        "tags": [],
         "intro": [
             "Doesn't it drive you insane, being cooped up inside camp all day?",
             "What about the thrill of adventure? The wind in your fur? The satisfaction of killing a hard-earned piece of prey?",
@@ -2759,6 +2760,9 @@
         "y_c": {
             "condition": [
                 "blind:any:false"
+            ],
+            "status": [
+                "mediator"
             ]
         },
         "t_c": {
@@ -2767,19 +2771,14 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "you_meditator"
             ]
         },
-        "tags": [
-            "you_meditator"
-        ],
+        "tags": [],
         "intro": [
             "y_c!! Ah- erm- uh- I'm not- I'm not upset-",
             "Mmmnmnnnn- Fine, you caught me... I just... I didn't wanna worry you...",
-            "See... r_c said something that I really... really don't agree with, you know? And I don't know how to tell them... every time I go to, it feels like the words die in my throat, and I wonder if I'm the one in the wrong.",
-            "... Can you help me, please? It um.. It really hurt my feelings, and I don't wanna be rude at all... But I need to tell {PRONOUN/r_c/object}."
+            "See... r_c said something that I really don't agree with, you know? And I don't know how to tell {PRONOUN/r_c/object}... every time I go to, it feels like the words die in my throat, and I wonder if I'm the one in the wrong.",
+            "... Can you help me, please? It really hurt my feelings, and I don't wanna be rude at all... But I need to tell {PRONOUN/r_c/object}."
         ]
     },
     "sweet_apprentice_19": {
@@ -4463,6 +4462,9 @@
         "y_c": {
             "condition": [
                 "blind:any:false"
+            ],
+            "status": [
+                "mediator"
             ]
         },
         "t_c": {
@@ -4471,16 +4473,11 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "you_meditator"
             ]
         },
-        "tags": [
-            "you_meditator"
-        ],
+        "tags": [],
         "intro": [
-            "Gah! You have no idea how much I- dislike o_c_n, I mean, just who do they think they are? The hunting ground in the west belongs to c_n, not their stinky hides.",
+            "Gah! You have no idea how much I dislike o_c_n, I mean, just who do they think they are? The hunting ground in the west belongs to c_n, not their stinky hides.",
             "[You frown. Yes, you're aware that the discussion with the opposing Clan led to this... Unfortunately, when you approached the Clan and their mediator, it didn't go too smoothly...]",
             "[You agree with t_c, the land rightfully belongs to c_n, not them.]",
             "I'm sorry, y_c, I didn't mean to make you mad or upset, it just gets on my nerves. But I trust that my Clanmates will be able to stand up for what we believe in.",
@@ -4488,18 +4485,18 @@
         ]
     },
     "stable_apprentice_32": {
-        "y_c": {},
+        "y_c": {
+            "status": [
+                "mediator",
+                "mediator apprentice"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "stable"
-            ],
-            "status": [
-                "you_meditator"
             ]
         },
-        "tags": [
-            "you_meditator"
-        ],
+        "tags": [],
         "intro": [
             "[tm_n wasn't available for training today for t_c, so you offered a paw in support. Now, at sunhigh, where the breeze is light and the smells are clear you find yourself walking with the apprentice, guided by {PRONOUN/t_c/poss} judgement.]",
             "[You may be a mediator, but you know the territory well, probably better than most. Yet this was a good chance for t_c to test {PRONOUN/t_c/poss} knowledge. As of so far, {PRONOUN/t_c/subject} {VERB/t_c/were/was} doing well.]",
@@ -4833,7 +4830,8 @@
     "upstanding_apprentice12": {
         "y_c": {
             "status": [
-                "mediator apprentice"
+                "mediator apprentice",
+                "mediator"
             ]
         },
         "t_c": {
@@ -4842,14 +4840,9 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "you_meditator"
             ]
         },
-        "tags": [
-            "you_meditator"
-        ],
+        "tags": [],
         "intro": [
             "[You're just about to bite into a tasty-looking mouse when you see t_c stomping towards you, {PRONOUN/t_c/poss} pelt ruffled and {PRONOUN/t_c/poss} tail flicking irritably. What happened this time?]",
             "y_c. I need you to tell r_a that {PRONOUN/r_a/subject} can't just leave me alone to clean out the entire elders' den because {PRONOUN/r_a/subject} 'needed to fetch more moss.' {PRONOUN/r_a/subject/CAP} {VERB/t_c/were/was} in the medicine den until sunhigh!",
@@ -6953,7 +6946,8 @@
     "brooding_toqueen_AJ": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -6971,9 +6965,7 @@
                 "deputy"
             ]
         },
-        "tags": [
-            "you_queen's_aprentice"
-        ],
+        "tags": [],
         "intro": [
             "[The nursery entrance shudders open, revealing little r_k dangling from t_c's mouth, mewling and squirming in protest.]",
             "[t_c sets {PRONOUN/r_k/object} on the ground, and the kit bounds towards you, cowering behind your leg at t_c's cold glare.]",
@@ -6984,7 +6976,8 @@
     "brooding_toqueen_AJ1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -7000,7 +6993,6 @@
             ]
         },
         "tags": [
-            "you_queen's_aprentice",
             "clan_has_kits"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -5055,11 +5055,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "D-don't hurt me! I didn't realize anyone else was here!",
             "[The ghostly cat backs away from you, {PRONOUN/t_c/poss} fur bristling. Is this a game?]",
@@ -6547,11 +6548,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "skill": [
+                "ARTISTAN,1"
             ]
         },
-        "tags": [
-            "they_artistian"
-        ],
+        "tags": [],
         "intro": [
             "[t_c is decorating a mucky rock overhang. You creep forward to inspect {PRONOUN/t_c/poss} creation.]",
             "[All of the foul-smelling components seem wrong. Is that a tuft of fur? Why is that piece of wood dripping?]",

--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -3822,7 +3822,7 @@
         },
         "relationship": [
             "from_parent",
-            "from_adoptive_parent"
+            "from_adopted_parent"
         ],
         "tags": [],
         "intro": [
@@ -3888,7 +3888,7 @@
         },
         "relationship": [
             "from_parent",
-            "from_adoptive_parent"
+            "from_adopted_parent"
         ],
         "tags": [],
         "intro": [

--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -3821,11 +3821,10 @@
             ]
         },
         "relationship": [
-            "from_parent"
-        ],
-        "tags": [
+            "from_parent",
             "from_adoptive_parent"
         ],
+        "tags": [],
         "intro": [
             "Hey, y_c. Tell me, what would you like to be when you grow up?"
         ],
@@ -3888,11 +3887,10 @@
             ]
         },
         "relationship": [
-            "from_parent"
-        ],
-        "tags": [
+            "from_parent",
             "from_adoptive_parent"
         ],
+        "tags": [],
         "intro": [
             "Hey, y_c. Tell me, what would you like to be when you grow up?"
         ],
@@ -4721,6 +4719,9 @@
         ]
     },
     "theyallergies_SL2": {
+        "season": [
+            "newleaf"
+        ],
         "y_c": {
             "age": [
                 "not_kitten"
@@ -4737,9 +4738,7 @@
                 "not_kitten"
             ]
         },
-        "tags": [
-            "Newleaf"
-        ],
+        "tags": [],
         "intro": [
             "Ugh!",
             "[t_c lets out an irritated groan before suddenly breaking out into a sneezing fit.]",

--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -5489,6 +5489,9 @@
             "age": [
                 "adolescent",
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -5505,9 +5508,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "You've been an apprentice for a bit, now. Do you like training with me, or with m_n better?",
             "[t_c's eyes flash for a moment. {PRONOUN/t_c/poss/CAP} tail flicks as {PRONOUN/t_c/subject} {VERB/t_c/await/awaits} your answer.]"

--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -738,7 +738,7 @@
     "assertivekit_1": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ],
             "condition": [
                 "blind:any:false"

--- a/resources/dicts/lifegen_talk/deputy.json
+++ b/resources/dicts/lifegen_talk/deputy.json
@@ -5484,7 +5484,8 @@
     "brooding_toqueen_AJ1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -5500,7 +5501,6 @@
             ]
         },
         "tags": [
-            "you_queen's_aprentice",
             "clan_has_kits"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/elder.json
+++ b/resources/dicts/lifegen_talk/elder.json
@@ -2843,7 +2843,7 @@
                 "elder"
             ]
         },
-        "tags": [
+        "relationship": [
             "they_grandparent"
         ],
         "intro": [
@@ -2867,7 +2867,7 @@
                 "elder"
             ]
         },
-        "tags": [
+        "relationship": [
             "they_grandparent"
         ],
         "intro": [
@@ -3268,11 +3268,10 @@
         },
         "relationship": [
             "max_platonic_30",
-            "max_trust_30"
-        ],
-        "tags": [
+            "max_trust_30",
             "they_grandparent"
         ],
+        "tags": [],
         "intro": [
             "You have put disgrace on the family's name. How is my precious y_p suppose to succeed now?",
             "A murderer as {PRONOUN/y_p/poss} heir... tsk tsk tsk."
@@ -3299,11 +3298,10 @@
         },
         "relationship": [
             "max_platonic_30",
-            "min_dislike_30"
-        ],
-        "tags": [
+            "min_dislike_30",
             "they_grandparent"
         ],
+        "tags": [],
         "intro": [
             "You have disappointed me, young one.",
             "... Well, more than normal."
@@ -3614,11 +3612,10 @@
         },
         "relationship": [
             "max_platonic_30",
-            "max_trust_30"
-        ],
-        "tags": [
+            "max_trust_30",
             "they_grandparent"
         ],
+        "tags": [],
         "intro": [
             "I trust StarClan will punish you enough to realize your mistake."
         ]

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -6409,7 +6409,8 @@
             "min_romantic_20"
         ],
         "tags": [
-            "accept"
+            "accept",
+            "has_mate"
         ],
         "intro": [
             "Does everycat want a piece of me, or what?",
@@ -6729,7 +6730,8 @@
             "non-mates"
         ],
         "tags": [
-            "reject"
+            "reject",
+            "has_mate"
         ],
         "intro": [
             "Sorry, you're definitely not my type of cat."

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -962,9 +962,6 @@
     },
     "oldflirts_41": {
         "y_c": {
-            "status": [
-                "warrior"
-            ],
             "condition": [
                 "blind:any:false"
             ]
@@ -1023,6 +1020,9 @@
                 "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -1417,8 +1417,10 @@
             ]
         },
         "tags": [
-            "reject",
-            "has_mate"
+            "reject"
+        ],
+        "relationship": [
+            "non-mates"
         ],
         "intro": [
             "Uh ... hehe! How sweet of you.",
@@ -1441,6 +1443,9 @@
                 "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -1912,6 +1917,9 @@
             ],
             "condition": [
                 "blind:any:false"
+            ],
+            "age": [
+                "adult"
             ]
         },
         "relationship": [
@@ -2013,10 +2021,17 @@
         ]
     },
     "brooding_flirt_AJ": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2031,6 +2046,9 @@
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2042,10 +2060,17 @@
         ]
     },
     "brooding_flirt_AJ2": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2056,10 +2081,17 @@
         ]
     },
     "brooding_flirt_AJ3": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2070,10 +2102,18 @@
         ]
     },
     "brooding_flirt_AJ4": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
             ]
         },
         "tags": [
@@ -2084,10 +2124,17 @@
         ]
     },
     "brooding_flirt_AJ5": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2098,12 +2145,22 @@
         ]
     },
     "brooding_flirt_AJ6": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -2127,10 +2184,18 @@
         ]
     },
     "brooding_flirt_AJ8": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
-                "brooding"
+                "brooding",
+                "unlawful"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "relationship": [
@@ -2150,6 +2215,9 @@
         "t_c": {
             "cluster": [
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2271,11 +2339,7 @@
         ]
     },
     "cool_flirt_AJ4": {
-        "y_c": {
-            "condition": [
-                "blind:any:false"
-            ]
-        },
+        "y_c": {},
         "t_c": {
             "cluster": [
                 "cool",
@@ -2522,7 +2586,11 @@
         ]
     },
     "oldflirts_88": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "stable",
@@ -2563,7 +2631,11 @@
         ]
     },
     "oldflirts_90": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "sweet",
@@ -2633,6 +2705,9 @@
             "cluster": [
                 "unlawful",
                 "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -2765,7 +2840,7 @@
             "reject"
         ],
         "intro": [
-            "..That was an awful attempt at flirting, but you are cute, so I'll let it slide."
+            "... That was an awful attempt at flirting, but you are cute, so I'll let it slide."
         ]
     },
     "oldflirts_100": {
@@ -2831,7 +2906,7 @@
             "reject"
         ],
         "intro": [
-            "...Hahaha! At least you're funny."
+            "... Hahaha! At least you're funny."
         ]
     },
     "upstanding_reject": {
@@ -2891,7 +2966,11 @@
         ]
     },
     "oldflirts_105": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "unlawful",
@@ -3053,12 +3132,19 @@
         ]
     },
     "oldflirts_112": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "unabashed",
                 "sweet",
                 "silly"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -3112,7 +3198,8 @@
             ]
         },
         "relationship": [
-            "from_mate"
+            "from_mate",
+            "min_romantic_20"
         ],
         "tags": [
             "accept"
@@ -3194,11 +3281,18 @@
         ]
     },
     "oldflirts_118": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "unlawful",
                 "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -3232,7 +3326,11 @@
         ]
     },
     "oldflirts_120": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "introspective"
@@ -3310,7 +3408,11 @@
         ]
     },
     "oldflirts_124": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "silly"
@@ -3330,6 +3432,9 @@
                 "unabashed",
                 "cool",
                 "silly"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -3400,11 +3505,22 @@
         ]
     },
     "oldflirts_129": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "unabashed",
                 "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "deputy",
+                "leader"
             ]
         },
         "tags": [
@@ -3425,13 +3541,16 @@
             "cluster": [
                 "silly",
                 "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
             "accept"
         ],
         "intro": [
-            "Arrggh, stop making me feel weird! It feels like there's butterflies in my belly whenever I see you as is!"
+            "Arrggh, stop making me feel weird! It feels like there's butterflies in my belly whenever I'm with you as is!"
         ]
     },
     "oldflirts_131": {
@@ -3451,7 +3570,8 @@
             ]
         },
         "relationship": [
-            "from_mate"
+            "from_mate",
+            "max_dislike_25"
         ],
         "tags": [
             "accept"
@@ -3629,6 +3749,9 @@
                 "heartbroken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "accept"
         ],
@@ -3705,7 +3828,7 @@
             "accept"
         ],
         "intro": [
-            "I need some time to heal. Please understand."
+            "I need some time to heal from this heartbreak. Please understand."
         ]
     },
     "heartbroken_5": {
@@ -3795,7 +3918,7 @@
             ]
         },
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "Not the time or the place. Move along."
@@ -3842,7 +3965,7 @@
             ]
         },
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "That's cool, but I've got other things on my mind."
@@ -3864,11 +3987,14 @@
                 "heartbroken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "accept"
         ],
         "intro": [
-            "Life's strange, isn't it? I'm still trying to recover from my last relationship, and here you are."
+            "Life's strange, isn't it? I'm still trying to recover from my last relationship, and yet here you are."
         ]
     },
     "heartbroken_12": {
@@ -3888,8 +4014,11 @@
                 "heartbroken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "Kind words, but I'm walking a solitary path for now."
@@ -3912,8 +4041,11 @@
                 "heartbroken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "Why now? Why me?"
@@ -3936,8 +4068,11 @@
                 "heartbroken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "Trust is earned. Let's keep things as they are."
@@ -3988,7 +4123,7 @@
             "accept"
         ],
         "intro": [
-            "I'm... Taking things slow right now."
+            "I'm... Taking things slow right now, but thank you."
         ]
     },
     "flirt_sh_J25": {
@@ -4003,6 +4138,9 @@
                 "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -4095,7 +4233,7 @@
             "accept"
         ],
         "intro": [
-            "[t_c playfully taps you with {PRONOUN/t_c/poss} tail before pulling it away before anyone can see.]"
+            "[t_c playfully taps you with {PRONOUN/t_c/poss} tail before pulling it away before anycat can see.]"
         ]
     },
     "flirt_sh_J30": {
@@ -4148,8 +4286,13 @@
                 "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates",
+            "min_dislike_25",
+            "min_romantic_10"
+        ],
         "tags": [
-            "accept"
+            "reject"
         ],
         "intro": [
             "Maybe I could have liked you if you weren't so evil."
@@ -4193,7 +4336,7 @@
             "accept"
         ],
         "intro": [
-            "What's going on..?"
+            "What's going on...?"
         ]
     },
     "flirt_sh_J35": {
@@ -4214,7 +4357,7 @@
             "accept"
         ],
         "intro": [
-            "What's going on..?"
+            "y_c...?"
         ]
     },
     "flirt_sh_J36": {
@@ -4234,7 +4377,7 @@
             "accept"
         ],
         "intro": [
-            "What's going on..?"
+            "What's going on...?"
         ]
     },
     "flirt_sh_J37": {
@@ -4253,7 +4396,7 @@
             "accept"
         ],
         "intro": [
-            "What's going on..?"
+            "What's going on...?"
         ]
     },
     "flirt_sh_J38": {
@@ -4279,9 +4422,16 @@
     },
     "flirt_sh_J39": {
         "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
             "shunned": true
         },
-        "t_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "tags": [
             "reject",
             "accept"
@@ -4291,9 +4441,16 @@
         ]
     },
     "flirt_sh_J40": {
-        "y_c": {},
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "t_c": {
-            "shunned": true
+            "shunned": true,
+            "condition": [
+                "blind:any:false"
+            ]
         },
         "tags": [
             "reject",
@@ -4340,11 +4497,11 @@
             ]
         },
         "t_c": {
-            "condition": [
-                "blind:any:false"
-            ],
             "shunned": true
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -4366,10 +4523,17 @@
             ],
             "shunned": true
         },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept",
+            "reject"
+        ],
         "intro": [
             "[You approached t_c, quietly starting to flirt with {PRONOUN/t_c/object}.]",
-            "y_c. I murdered our Clanmate. Why are you talking to me, let alone like this?",
-            "[You tell t_c that you never liked that Clanmate anyway, and maybe you like a little danger too.]"
+            "y_c. I murdered neutral-v_c. Why are you talking to me, let alone like this?",
+            "[You tell t_c that you never liked neutral-v_c anyway, and maybe you like a little danger too.]"
         ]
     },
     "flirting_shunned_Ren2": {
@@ -4384,20 +4548,21 @@
             ],
             "shunned": true
         },
+        "relationship": [
+            "non-mates",
+            "min_dislike_10"
+        ],
         "tags": [
             "reject"
         ],
         "intro": [
             "[You decide to start flirting with t_c in an attempt to see where it leads. {PRONOUN/t_c/subject/CAP} {VERB/t_c/do/does} not seem amused.]",
-            "y_c. I murdered our Clanmate. I'm not afraid to go after you too if you keep at it.",
+            "y_c. I murdered v_c. I'm not afraid to go after you too if you keep at it.",
             "[You try one more time, but t_c lashes out at you, not afraid to get more blood on {PRONOUN/t_c/poss} claws. It seems {PRONOUN/t_c/subject} {VERB/t_c/aren't/isn't} too fond of you.]"
         ]
     },
     "flirting_shunned_SQ3": {
         "y_c": {
-            "condition": [
-                "blind:any:false"
-            ],
             "shunned": true
         },
         "t_c": {
@@ -4405,6 +4570,9 @@
                 "blind:any:false"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -4537,16 +4705,9 @@
     },
     "flirting_shunned_SQ4": {
         "y_c": {
-            "condition": [
-                "blind:any:false"
-            ],
             "shunned": true
         },
-        "t_c": {
-            "condition": [
-                "blind:any:false"
-            ]
-        },
+        "t_c": {},
         "tags": [
             "accept"
         ],
@@ -4574,7 +4735,7 @@
             "accept"
         ],
         "intro": [
-            ".. That gives me an idea, y_c.",
+            "... That gives me an idea, y_c.",
             "c_n will never see us the same. We'll always be the dirt on their paws because we have blood on our own.",
             "We should leave, y_c, make something for us - maybe an entire Clan. But I won't leave until you're ready to come with me.",
             "I couldn't do it alone."
@@ -4587,6 +4748,9 @@
         "t_c": {
             "shunned": true
         },
+        "relationship": [
+            "min_dislike_10"
+        ],
         "tags": [
             "reject"
         ],
@@ -4621,24 +4785,23 @@
         ]
     },
     "grieving_flirt_CM1": {
-        "y_c": {
-            "condition": [
-                "blind:any:false"
-            ]
-        },
+        "y_c": {},
         "t_c": {
             "condition": [
                 "blind:any:false",
                 "grief stricken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
         "intro": [
             "[t_c barely looks up at you, choking out a sob as {PRONOUN/t_c/subject} {VERB/t_c/tremble/trembles}.]",
             "y_c, y_c I'm sorry. I- <i>hic</i> I can't...",
-            "I can't love anyone like I did tg_c.",
+            "I can't love anyone like I did plike-tg_c.",
             "It... if I lost you... it would destroy me if I did."
         ]
     },
@@ -4816,6 +4979,9 @@
                 "grief stricken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -5006,6 +5172,9 @@
                 "grief stricken"
             ]
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -5496,9 +5665,6 @@
             ],
             "shunned": true
         },
-        "relationship": [
-            "from_mate"
-        ],
         "tags": [
             "reject"
         ],
@@ -5518,6 +5684,9 @@
             ],
             "shunned": true
         },
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -5599,7 +5768,6 @@
             "shunned": true
         },
         "tags": [
-            "accept",
             "accept"
         ],
         "intro": [
@@ -5739,6 +5907,9 @@
                 "unlawful",
                 "brooding",
                 "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
             ]
         },
         "tags": [
@@ -5876,7 +6047,7 @@
             ]
         },
         "relationship": [
-            "min_platonic_50"
+            "min_platonic_30"
         ],
         "tags": [
             "accept"
@@ -5920,7 +6091,6 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
             "non-mates"
         ],
         "tags": [
@@ -5970,7 +6140,7 @@
         ],
         "intro": [
             "... Right, that made no sense.",
-            "You should work on your flirting a little more before you come back for more."
+            "You should work on your flirting a little more before you try again."
         ]
     },
     "flirt_reject_H5": {
@@ -6036,14 +6206,14 @@
             "leafbare"
         ],
         "relationship": [
-            "min_platonic_50"
+            "min_platonic_15"
         ],
         "tags": [
             "reject"
         ],
         "intro": [
             "What are you doing outside? It's so cold!",
-            "[t_c coaxes you back to somewhere warm and alas, your attempt at flirting either went over {PRONOUN/t_c/poss} head... or was ignored.]",
+            "[t_c coaxes you back to somewhere warm. Alas, your attempt at flirting either went over {PRONOUN/t_c/poss} head... or was ignored.]",
             "[You can't decide which one is worse.]"
         ]
     },
@@ -6079,26 +6249,24 @@
             ]
         },
         "tags": [
-            "reject",
-            "has_mate"
+            "reject"
         ],
         "intro": [
             "You have some nerve..."
         ]
     },
     "blind_to_grieving_H1": {
-        "y_c": {
+        "y_c": {},
+        "t_c": {
             "condition": [
                 "blind:any:false"
             ]
         },
-        "t_c": {},
         "relationship": [
             "grievingyou"
         ],
         "tags": [
-            "reject",
-            "flirt"
+            "reject"
         ],
         "intro": [
             "I don't understand how you can flirt with me right now!",
@@ -6162,7 +6330,6 @@
             "min_romantic_20"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
@@ -6177,11 +6344,10 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
+            "min_dislike_20",
             "min_romantic_20"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
@@ -6197,18 +6363,18 @@
         },
         "t_c": {
             "condition": [
-                "deaf:any:false"
+                "deaf:any:false",
+                "blind:any:false"
             ]
         },
         "relationship": [
             "min_romantic_20"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
-            "[t_c looks away, flustered by your flirting.]",
+            "[t_c turns away, flustered by your flirting.]",
             "[Just over {PRONOUN/t_c/poss} shoulder, you see t_m watching from the distance, {PRONOUN/t_m/poss} tail lashing.]",
             "[... Whoops.]"
         ]
@@ -6224,7 +6390,6 @@
             "min_romantic_20"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
@@ -6244,7 +6409,6 @@
             "min_romantic_20"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
@@ -6268,7 +6432,6 @@
             "from_mate"
         ],
         "tags": [
-            "has_mate",
             "accept"
         ],
         "intro": [
@@ -6331,6 +6494,9 @@
             ]
         },
         "t_c": {},
+        "relationship": [
+            "non-mates"
+        ],
         "tags": [
             "reject"
         ],
@@ -6373,7 +6539,8 @@
                 "blind:any:false"
             ],
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "relationship": [
@@ -6451,7 +6618,6 @@
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6474,7 +6640,6 @@
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6497,7 +6662,6 @@
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6517,11 +6681,10 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
+            "min_dislike_30",
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6540,11 +6703,10 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
+            "min_dislike_30",
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6567,7 +6729,6 @@
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6600,12 +6761,15 @@
     },
     "hasmate_reject_H8": {
         "y_c": {},
-        "t_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
         "relationship": [
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6628,7 +6792,6 @@
             "non-mates"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6645,10 +6808,10 @@
             ]
         },
         "relationship": [
-            "non-mates"
+            "non-mates",
+            "min_dislike_10"
         ],
         "tags": [
-            "has_mate",
             "reject"
         ],
         "intro": [
@@ -6691,8 +6854,7 @@
             "from_mate"
         ],
         "tags": [
-            "accept",
-            "flirt"
+            "accept"
         ],
         "intro": [
             "Haha...",
@@ -6754,7 +6916,6 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
             "from_mate"
         ],
         "tags": [
@@ -6798,7 +6959,6 @@
             ]
         },
         "relationship": [
-            "min_dislike_50",
             "from_mate"
         ],
         "tags": [
@@ -6926,14 +7086,11 @@
         "y_c": {
             "condition": [
                 "deaf:any:true"
-            ],
-            "age": [
-                "not_kitten"
             ]
         },
         "t_c": {
-            "age": [
-                "not_kitten"
+            "condition": [
+                "deaf:any:false"
             ]
         },
         "relationship": [
@@ -6993,7 +7150,7 @@
     "youdeaf_R84": {
         "y_c": {
             "condition": [
-                "deaf:any:true"
+                "deaf:any:false"
             ]
         },
         "t_c": {
@@ -7011,7 +7168,7 @@
     "youdeaf_R85": {
         "y_c": {
             "condition": [
-                "deaf:any:true"
+                "deaf:any:false"
             ]
         },
         "t_c": {
@@ -8505,6 +8662,10 @@
         "relationship": [
             "from_mate"
         ],
+        "tags": [
+            "accept",
+            "reject"
+        ],
         "intro": [
             "[You press against t_c. {PRONOUN/t_c/subject/CAP} {VERB/t_c/keep/keeps} {PRONOUN/t_c/poss} eyes closed, but press back against you.]",
             "[You think you hear a small purr, but it quickly turns to sobs.]"
@@ -8569,6 +8730,9 @@
             ],
             "shunned": true
         },
+        "tags": [
+            "accept"
+        ],
         "intro": [
             "[t_c smiles slightly. Even though {PRONOUN/t_c/subject} {VERB/t_c/seem/seems} hesitant, t_c doesn't appear to hate your flirting.]"
         ]
@@ -8690,7 +8854,8 @@
         },
         "t_c": {
             "condition": [
-                "grief stricken"
+                "grief stricken",
+                "deaf:any:false"
             ]
         },
         "intro": [

--- a/resources/dicts/lifegen_talk/flirt.json
+++ b/resources/dicts/lifegen_talk/flirt.json
@@ -6865,11 +6865,11 @@
         "t_c": {
             "condition": [
                 "blind:any:false",
-                "deaf:any:false"
+                "deaf:any:false",
+                "guilt"
             ]
         },
         "tags": [
-            "they_guilty",
             "reject"
         ],
         "intro": [
@@ -6888,11 +6888,11 @@
         "t_c": {
             "condition": [
                 "blind:any:false",
-                "deaf:any:false"
+                "deaf:any:false",
+                "guilt"
             ]
         },
         "tags": [
-            "they_guilty",
             "accept"
         ],
         "intro": [
@@ -6907,14 +6907,14 @@
         },
         "t_c": {
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "guilt"
             ]
         },
         "relationship": [
             "from_mate"
         ],
         "tags": [
-            "they_guilty",
             "reject"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/focuses/halloween.json
+++ b/resources/dicts/lifegen_talk/focuses/halloween.json
@@ -180,7 +180,7 @@
     "halloween_J7": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ],
             "condition": [
                 "blind:any:false"
@@ -434,7 +434,7 @@
     "Halloween_SV5": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ],
             "condition": [
                 "blind:any:false"

--- a/resources/dicts/lifegen_talk/focuses/halloween.json
+++ b/resources/dicts/lifegen_talk/focuses/halloween.json
@@ -489,13 +489,15 @@
             ],
             "dead": [
                 "any"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
         "season": [
             "leaffall"
         ],
         "tags": [
-            "they_kittypet",
             "halloween"
         ],
         "intro": [
@@ -517,15 +519,17 @@
             ],
             "dead": [
                 "any"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
         "tags": [
-            "they_kittypet",
             "halloween"
         ],
         "intro": [
             "[While all the other kittypets you've talked to lately are excited for the incoming 'visit' to their Twolegs, t_c is curled away in the distance.]",
-            "Sorry for being all moppy. I didn't want to ruin the good mood.",
+            "Sorry for being all mopey. I didn't want to ruin the good mood.",
             "I just... I know I'm not in my previous Twolegs pictures. I should be optimistic and have some faith!",
             "But I know lying to myself is just going to cause more pain."
         ]
@@ -538,11 +542,13 @@
             ],
             "dead": [
                 "any"
+            ],
+            "status": [
+                "loner",
+                "rogue"
             ]
         },
         "tags": [
-            "they_loner",
-            "they_rogue",
             "halloween"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/focuses/leader.json
+++ b/resources/dicts/lifegen_talk/focuses/leader.json
@@ -1173,7 +1173,7 @@
             "focus"
         ],
         "intro": [
-            "I hope to see the day d_n takes {PRONOUN/l_n/poss} place."
+            "I hope to see the day d_n takes l_n's place."
         ]
     },
     "bad_opinion_AJ": {

--- a/resources/dicts/lifegen_talk/focuses/unknown_murder.json
+++ b/resources/dicts/lifegen_talk/focuses/unknown_murder.json
@@ -1874,7 +1874,6 @@
             ]
         },
         "tags": [
-            "focus",
             "focus"
         ],
         "intro": [
@@ -2418,10 +2417,12 @@
                 "elder"
             ]
         },
+        "relationship": [
+            "they_grandparent"
+        ],
         "tags": [
             "focus",
-            "you_murderer",
-            "grandparent"
+            "you_murderer"
         ],
         "intro": [
             "Dear, you have been very smug lately. Don't think I can't tell.",

--- a/resources/dicts/lifegen_talk/focuses/unknown_murder.json
+++ b/resources/dicts/lifegen_talk/focuses/unknown_murder.json
@@ -2068,7 +2068,7 @@
     "unknown_murder_J12": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ]
         },
         "t_c": {

--- a/resources/dicts/lifegen_talk/focuses/war.json
+++ b/resources/dicts/lifegen_talk/focuses/war.json
@@ -2665,7 +2665,8 @@
                 "warrior",
                 "apprentice",
                 "deputy",
-                "leader"
+                "leader",
+                "not_df_trainee"
             ]
         },
         "t_c": {
@@ -2680,8 +2681,7 @@
             ]
         },
         "tags": [
-            "focus",
-            "you_not_dftrainee"
+            "focus"
         ],
         "intro": [
             "[On patrol with t_c and r_w today, you were ambushed by a small group of w_cClan warriors.]",

--- a/resources/dicts/lifegen_talk/focuses/war.json
+++ b/resources/dicts/lifegen_talk/focuses/war.json
@@ -3454,13 +3454,15 @@
             ],
             "dead": [
                 "any"
+            ],
+            "status": [
+                "kittypet",
+                "rogue",
+                "loner"
             ]
         },
         "tags": [
-            "focus",
-            "they_kittypet",
-            "they_rogue",
-            "they_loner"
+            "focus"
         ],
         "intro": [
             "Ah, you never got old enough to have to deal with all of this... Clancat violence, did you?",

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -30618,6 +30618,9 @@
             ],
             "condition": [
                 "blind:any:false"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30637,9 +30640,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "So, what's the waking world like? How's your training going there?",
             "[t_c swipes at your face. You twist aside just as {PRONOUN/t_c/subject} taught you, and {PRONOUN/t_c/subject} {VERB/t_c/purr/purrs} approvingly.]",
@@ -30654,6 +30655,9 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30670,9 +30674,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "You look terrible. I'm not going to train you when you're like that.",
             "Why are you even here tonight? Are you trying to spread whatever you have?",
@@ -30687,6 +30689,9 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30706,9 +30711,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "So you're going to have kits, hmm?",
             "Well... good luck, y_c. But don't stop training with me just because you'll have some furballs to look after.",
@@ -30722,6 +30725,9 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30741,9 +30747,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "Don't wander too deep into the forest. If you go too far, you might never come out.",
             "There are some cruel cats in there, and they've had lifetimes to hone their skills. Let me train you just a little more, first."
@@ -30753,7 +30757,8 @@
         "y_c": {
             "status": [
                 "medicine cat",
-                "medicine cat apprentice"
+                "medicine cat apprentice",
+                "df_trainee"
             ],
             "age": [
                 "not_kitten"
@@ -30776,9 +30781,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "[You glimpse what seems to be a deep claw wound beneath the muck caking t_c's pelt, and ask if {PRONOUN/t_c/subject}'d like you to look at it. t_c hisses.]",
             "Remember your place, y_c. I'm your <i>mentor.</i> I can take care of myself.",
@@ -30790,6 +30793,9 @@
         "y_c": {
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30806,9 +30812,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "[You're training with t_c when the ground suddenly shudders beneath you. You both leap away as the earth collapses and your training space is swallowed by dark muck.]",
             "[t_c doesn't look at you. They stare at the sinkhole, quivering. Their eyes are wide as they slowly back away from it.]",
@@ -30819,6 +30823,9 @@
         "y_c": {
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30838,9 +30845,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "[During a break between tonight's exercises, you ask t_c a few questions about {PRONOUN/t_c/self}. You're careful not to ask anything too sensitive, but t_c still looks uncomfortable.]",
             "I'm... uh... flattered that you're interested, but I don't have much to say.",
@@ -30851,6 +30856,9 @@
         "y_c": {
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30867,9 +30875,7 @@
         "relationship": [
             "from_df_mentor"
         ],
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "[Your previous attempts to ask t_c about {PRONOUN/t_c/self} have been unsuccessful, so you try to ask {PRONOUN/t_c/object} what the world was like when {PRONOUN/t_c/subject} {VERB/t_c/were/was} alive, instead. {PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} look at you.]",
             "You don't have to pretend to be interested in me, y_c. I know you're just here to train.",
@@ -30880,6 +30886,9 @@
         "y_c": {
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30893,9 +30902,7 @@
                 "not_kitten"
             ]
         },
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "Life's too short to sit and take what other cats do to you.",
             "If someone's making your life miserable, it's okay to... do something about it, if you know what I mean.",
@@ -30908,6 +30915,9 @@
         "y_c": {
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "df_trainee"
             ]
         },
         "t_c": {
@@ -30921,9 +30931,7 @@
                 "not_kitten"
             ]
         },
-        "tags": [
-            "you_df_trainee"
-        ],
+        "tags": [],
         "intro": [
             "Don't listen to what the other cats here might say. They call me a coward. They think I'm weak.",
             "[t_c spits into the murk pooled around {PRONOUN/t_c/poss} paws.]",

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -44908,7 +44908,7 @@
 },
         "intro": [
            "[t_c purrs quietly as {PRONOUN/t_c/subject} {VERB/t_c/rest/rests} in a sunbeam. {PRONOUN/t_c/poss/CAP} eyes are closed, and {PRONOUN/t_c/subject} {VERB/t_c/look/looks} uncharacteristically content.]",
-           "[...{PRONOUN/t_c/subject/CAP} {VERB/t_c/seem/seems} to realize what {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} doing,  {VERB/t_c/sit/sits} up, and {VERB/t_c/fix/fixes} {PRONOUN/t_c/poss} usual scowl back on {PRONOUN/t_c/poss} face.]"
+           "[...{PRONOUN/t_c/subject/CAP} {VERB/t_c/seem/seems} to realize what {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} doing, {VERB/t_c/sit/sits} up, and {VERB/t_c/fix/fixes} {PRONOUN/t_c/poss} usual scowl back on {PRONOUN/t_c/poss} face.]"
 ]
 },
 

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -36500,7 +36500,8 @@
     "neurotic_yourecoveringfrombirth_SQ1": {
         "y_c": {
             "condition": [
-                "deaf:any:false"
+                "deaf:any:false",
+                "recovering from birth"
             ],
             "age": [
                 "not_kitten"
@@ -36520,9 +36521,7 @@
         "relationship": [
             "min_platonic_10"
         ],
-        "tags": [
-            "you_recoveringfrombirth"
-        ],
+        "tags": [],
         "intro": [
             "[t_c hovers outside of the nursery until you invite {PRONOUN/t_c/object} inside. {PRONOUN/t_c/subject/CAP} {VERB/t_c/step/steps} carefully, as if worried that a kitten will teleport underfoot.]",
             "[When you beckon {PRONOUN/t_c/object} forward to see y_kk, who's asleep by your side, {PRONOUN/t_c/poss} eyes widen. {PRONOUN/t_c/subject/CAP} {VERB/t_c/reach/reaches} out a paw to touch {PRONOUN/y_kk/object}, then quickly {VERB/t_c/pull/pulls} it back.]",
@@ -42246,7 +42245,8 @@
     "theypreg_sign_rad1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -42258,9 +42258,7 @@
                 "not_queen's apprentice"
             ]
         },
-        "tags": [
-            "you_queen_apprentice"
-        ],
+        "tags": [],
         "intro": [
             "Hey, y_c, what was the sign for moss-ball again?",
             "It's been awhile since I've been in the nursery, and I don't remember all the signs the kits use."

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -31733,16 +31733,15 @@
                 "neurotic"
             ],
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "guilt"
             ],
             "shunned": true,
             "age": [
                 "not_kitten"
             ]
         },
-        "tags": [
-            "they_guilty"
-        ],
+        "tags": [],
         "intro": [
             "[t_c, alone in the corner, mumbles the same things over and over again.]",
             "I didn't mean it. I didn't mean to do it...",
@@ -33673,11 +33672,12 @@
         "t_c": {
             "cluster": [
                 "assertive"
+            ],
+            "skill": [
+                "COMFORTER,1"
             ]
         },
-        "relationship": [
-            "they_comforter"
-        ],
+        "relationship": [],
         "intro": [
             "Well if it ain't y_c, how're you doin' today?",
             "You sure don't look great. Too much to do?",
@@ -33705,11 +33705,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "skill": [
+                "ARTISTAN,1"
             ]
         },
-        "tags": [
-            "they_artistian"
-        ],
+        "tags": [],
         "intro": [
             "[t_c is arranging brittle, blackened leaves in the semblance of a garland. {PRONOUN/t_c/subject/CAP} {VERB/t_c/try/tries} to hang them so they curl around one of the twisted trees, but the leaves keep cracking and falling to the ground.]",
             "[When t_c notices you watching, {PRONOUN/t_c/subject} {VERB/t_c/glare/glares} at you and {VERB/t_c/stalk/stalks} away. The leaves crumble to dust as {PRONOUN/t_c/subject} {VERB/t_c/vanish/vanishes}.]"
@@ -39018,7 +39019,8 @@
             ],
             "condition": [
                 "blind:any:false",
-                "deaf:any:false"
+                "deaf:any:false",
+                "guilt"
             ],
             "shunned": true
         },
@@ -39027,9 +39029,7 @@
             "min_trust_10",
             "from_mate"
         ],
-        "tags": [
-            "they_guilty"
-        ],
+        "tags": [],
         "intro": [
             "[t_c's head is buried underneath {PRONOUN/t_c/poss} paws as if hiding away from the world.]"
         ]

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -6394,7 +6394,7 @@
             ]
         },
         "intro": [
-            "They'll take care of yg_c in StarClan, I promise. {PRONOUN/t_c/subject/CAP}'ll be okay."
+            "They'll take care of yg_c in StarClan, I promise. {PRONOUN/yg_c/subject/CAP}'ll be okay."
         ]
     },
     "sweetgrief_yougrief7": {

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -4225,7 +4225,8 @@
     "cool_tomediatorAJ": {
         "y_c": {
             "status": [
-                "mediator"
+                "mediator",
+                "mediator's apprentice"
             ],
             "condition": [
                 "blind:any:false"
@@ -4246,9 +4247,7 @@
         "relationship": [
             "max_platonic_15"
         ],
-        "tags": [
-            "mediator's apprentice"
-        ],
+        "tags": [],
         "intro": [
             "Huh? Oh, I don't really need any mediation. Thanks."
         ]
@@ -4258,7 +4257,8 @@
             "status": [
                 "apprentice",
                 "queen's apprentice",
-                "medicine cat apprentice"
+                "medicine cat apprentice",
+                "mediator's apprentice"
             ],
             "condition": [
                 "blind:any:false"
@@ -4278,9 +4278,7 @@
         "relationship": [
             "max_platonic_10"
         ],
-        "tags": [
-            "mediator's apprentice"
-        ],
+        "tags": [],
         "intro": [
             "Shouldn't you be out with m_n ...?",
             "When I was your age, I'd never be caught dead shirking my duties."
@@ -25568,14 +25566,13 @@
             ]
         },
         "season": [
-            "greenleaf"
+            "greenleaf",
+            "leaffall"
         ],
         "biome": [
             "forest"
         ],
-        "tags": [
-            "leaf-fall"
-        ],
+        "tags": [],
         "intro": [
             "[After a recent windstorm, t_c has {PRONOUN/t_c/poss} nose to the ground, using {PRONOUN/t_c/poss} whiskers to navigate around all of the branches that have fallen into the clearing.]",
             "[Focussed on the debris underpaw, {PRONOUN/t_c/subject}{VERB/t_c/stop/stops} shorter of you than {PRONOUN/t_c/subject} normally would.]",
@@ -29063,10 +29060,10 @@
         },
         "relationship": [
             "min_platonic_50",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
         "tags": [
-            "adoptive_parent",
             "connected"
         ],
         "intro": [
@@ -29095,10 +29092,10 @@
         },
         "relationship": [
             "min_platonic_50",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
         "tags": [
-            "adoptive_parent",
             "connected"
         ],
         "intro": [
@@ -29127,10 +29124,10 @@
         },
         "relationship": [
             "min_platonic_50",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
         "tags": [
-            "adoptive_parent",
             "connected"
         ],
         "intro": [
@@ -29159,10 +29156,10 @@
         },
         "relationship": [
             "min_platonic_50",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
         "tags": [
-            "adoptive_parent",
             "connected"
         ],
         "intro": [
@@ -41161,11 +41158,10 @@
         },
         "relationship": [
             "min_platonic_20",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
-        "tags": [
-            "adoptive_parent"
-        ],
+        "tags": [],
         "intro": [
             "Ah... y_c? plike-m_n mentioned you hurt yourself while training... are you okay? Do you need to see r_m?",
             "[You indeed scraped your side on a rock today, but it only left a scratch. You show t_c, and {PRONOUN/t_c/subject} {VERB/t_c/take/takes} a while to inspect it.]",

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -1050,7 +1050,8 @@
         "y_c": {
             "backstory": [
                 "clanfounder",
-                "clanborn"
+                "clanborn",
+                "originallyfromanotherclan"
             ]
         },
         "t_c": {
@@ -1062,9 +1063,7 @@
                 "formerlyakittypet"
             ]
         },
-        "tags": [
-            "you_originallyanotherclan"
-        ],
+        "tags": [],
         "intro": [
             "Oh, hit the road, Jack.",
             "[You bristle in confusion, not understanding the terminology t_c just used for you. You ask what {PRONOUN/t_c/subject} {VERB/t_c/mean/means} by that, but t_c only grins.]",

--- a/resources/dicts/lifegen_talk/general_no_newborn.json
+++ b/resources/dicts/lifegen_talk/general_no_newborn.json
@@ -2469,7 +2469,8 @@
                 "silly"
             ],
             "age": [
-                "adolescent"
+                "adolescent",
+                "kitten"
             ],
             "condition": [
                 "blind:any:false"
@@ -2482,9 +2483,7 @@
             "min_platonic_20",
             "sibling"
         ],
-        "tags": [
-            "they_kit"
-        ],
+        "tags": [],
         "intro": [
             "Hey! Hey, hey, y_c! Hey!",
             "We should do something together sometime! Like... a sibling song! After all...",
@@ -2506,7 +2505,8 @@
                 "silly"
             ],
             "age": [
-                "adolescent"
+                "adolescent",
+                "kitten"
             ],
             "condition": [
                 "blind:any:false"
@@ -2518,9 +2518,7 @@
         "relationship": [
             "min_platonic_20"
         ],
-        "tags": [
-            "they_kit"
-        ],
+        "tags": [],
         "intro": [
             "I had an idea for a new song! Wanna hear it?",
             "What? 'I'm busy'? Well, that's perfect! Unwilling listeners are the best kind!",
@@ -3833,7 +3831,8 @@
             "cluster": [
                 "unabashed",
                 "silly",
-                "neurotic"
+                "neurotic",
+                "assertive"
             ],
             "age": [
                 "not_kitten"
@@ -3842,9 +3841,7 @@
         "relationship": [
             "min_platonic_25"
         ],
-        "tags": [
-            "they_asseritve"
-        ],
+        "tags": [],
         "intro": [
             "You ever notice how plike-r_c-introspective doesn't say much, but when {PRONOUN/plike-r_c-introspective/subject} {VERB/plike-r_c-introspective/do/does}, it's, like, the smartest thing you've ever heard?",
             "I swear, {PRONOUN/plike-r_c-introspective/subject}{VERB/plike-r_c-introspective/'re/'s} like a StarClan cat reincarnated, {PRONOUN/plike-r_c-introspective/subject}{VERB/plike-r_c-introspective/'re/'s} so wise. If I had a brain like that, I wouldn't be able to stand living in this Clan, every other cat would seem so mouse-brained!",

--- a/resources/dicts/lifegen_talk/general_outsider.json
+++ b/resources/dicts/lifegen_talk/general_outsider.json
@@ -511,39 +511,6 @@
             "I've always wondered how Clans worked. Can you tell me more about them?"
         ]
     },
-    "scnew_urnew_R1": {
-        "y_c": {
-            "status": [
-                "newborn"
-            ],
-            "condition": [
-                "blind:any:false"
-            ],
-            "dead": [
-                "sc"
-            ]
-        },
-        "t_c": {
-            "condition": [
-                "blind:any:false"
-            ],
-            "dead": [
-                "ur"
-            ],
-            "status": [
-                "newborn"
-            ]
-        },
-        "tags": [
-            "they_kittypet"
-        ],
-        "intro": [
-            "Meewwww!",
-            "[Oh? Who is that? You toddle closer curiously.]",
-            "Meeew mew.",
-            "[You're friends now. The day is spent napping together.]"
-        ]
-    },
     "scnew_urnew_R2": {
         "y_c": {
             "status": [
@@ -566,49 +533,15 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[You've met a strange new kit who smells weird.]",
             "[You both spend time sniffing and scrunching your noses at each other before calling an apparent truce.]",
             "[You toddle away first when a queen spots you.]"
-        ]
-    },
-    "scnew_urnew_R3": {
-        "y_c": {
-            "status": [
-                "newborn"
-            ],
-            "condition": [
-                "blind:any:false"
-            ],
-            "dead": [
-                "sc"
-            ]
-        },
-        "t_c": {
-            "condition": [
-                "blind:any:false"
-            ],
-            "dead": [
-                "ur"
-            ],
-            "status": [
-                "newborn"
-            ]
-        },
-        "tags": [
-            "they_kittypet"
-        ],
-        "intro": [
-            "Mew! Mew! Mew! Mew!",
-            "[What's that sound?]",
-            "Mew! Meeew! Meeeew! Meeeew!",
-            "[You decide to mew back, and soon there is a volley of tiny squeaks echoing softly between the two of you.]"
         ]
     },
     "scnew_urnew_R4": {
@@ -633,12 +566,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[A queen has noticed a strange newborn amongst the regulars. You already knew t_c was there.]",
             "[You snuggle closer to {PRONOUN/t_c/object}, laying your tiny head on the small of {PRONOUN/t_c/poss} back.]",
@@ -666,12 +598,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Mew. Mew. Mew. Mew. Mew. Mew. Meeeew.",
             "[Is that... t_c? {VERB/t_c/Aren't/Isn't} {PRONOUN/t_c/subject} a kittypet? You heard one of the queens say that before.]",
@@ -700,12 +631,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[In the middle of a scavenger hunt, you stumble across t_c!]",
             "[... Well... It wouldn't hurt to have a friend to join you!]",
@@ -735,12 +665,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[One of the queens asks you for a favor since they're alone with the newborns right now. t_c has wandered in, but it's time for {PRONOUN/t_c/object} to go home.]",
             "[The little kittypet wriggles as you struggle to carry {PRONOUN/t_c/object} to the border.]",

--- a/resources/dicts/lifegen_talk/general_outsider.json
+++ b/resources/dicts/lifegen_talk/general_outsider.json
@@ -404,7 +404,7 @@
     "dead_outsider_J16": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ]
         },
         "t_c": {

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -8010,11 +8010,10 @@
             ]
         },
         "relationship": [
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
-        "tags": [
-            "adoptive_parent"
-        ],
+        "tags": [],
         "intro": [
             "[Sometimes, t_c's smile flickers when {PRONOUN/t_c/subject} {VERB/t_c/notice/notices} how small you still are. {PRONOUN/t_c/subject/CAP} {VERB/t_c/lean/leans} close, pressing {PRONOUN/t_c/poss} face into your side.]",
             "I tried so hard to keep you safe, y_c. I'm sorry that it wasn't enough."
@@ -8047,11 +8046,10 @@
             ]
         },
         "relationship": [
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
-        "tags": [
-            "adoptive_parent"
-        ],
+        "tags": [],
         "intro": [
             "y_c, did I hear r_w right? Did you sneak into the warriors' den this morning?",
             "I know you're excited to grow up, but you can't do things like that! It's important to stay out of trouble, and not bother other cats...",

--- a/resources/dicts/lifegen_talk/insults.json
+++ b/resources/dicts/lifegen_talk/insults.json
@@ -6502,6 +6502,9 @@
             "condition": [
                 "deaf:any:false",
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "t_c": {
@@ -6510,7 +6513,8 @@
                 "blind:any:false"
             ],
             "status": [
-                "older"
+                "older",
+                "not_newborn"
             ]
         },
         "relationship": [
@@ -6541,12 +6545,18 @@
             "condition": [
                 "grief stricken",
                 "deaf:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "t_c": {
             "condition": [
                 "deaf:any:false",
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "relationship": [],
@@ -6562,11 +6572,17 @@
             "condition": [
                 "grief stricken",
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "t_c": {
             "condition": [
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "relationship": [
@@ -6584,11 +6600,17 @@
             "condition": [
                 "grief stricken",
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "t_c": {
             "condition": [
                 "blind:any:false"
+            ],
+            "status": [
+                "not_newborn"
             ]
         },
         "relationship": [],

--- a/resources/dicts/lifegen_talk/insults.json
+++ b/resources/dicts/lifegen_talk/insults.json
@@ -5921,7 +5921,8 @@
     "shunned_insults_H2": {
         "y_c": {
             "condition": [
-                "blind:any:false"
+                "blind:any:false",
+                "guilt"
             ],
             "shunned": true,
             "age": [
@@ -5937,7 +5938,6 @@
             ]
         },
         "tags": [
-            "you_guilty",
             "insult"
         ],
         "intro": [
@@ -6318,12 +6318,12 @@
                 "deaf:any:false"
             ],
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "tags": [
-            "insult",
-            "they_queen_apprentice"
+            "insult"
         ],
         "intro": [
             "[t_c cuffs your ear sharply.]"

--- a/resources/dicts/lifegen_talk/insults.json
+++ b/resources/dicts/lifegen_talk/insults.json
@@ -6620,5 +6620,87 @@
         "intro": [
             "You're just being a meanie 'cause yg_c left you!"
         ]
+    },
+    "mcgrievingonly_insult_H6": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "insult"
+        ],
+        "intro": [
+            "Oh, so now you think it's alright to insult people just because you're hurting? Give me a break."
+        ]
+    },
+    "mcgrievingonly_insult_H7": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "insult"
+        ],
+        "intro": [
+            "Oh, sorry, didn't realize grieving cats were so delusional."
+        ]
+    },
+    "mcgrievingonly_insult_H8": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "insult"
+        ],
+        "intro": [
+            "[t_c rolls {PRONOUN/t_c/poss} eyes.]"
+        ]
+    },
+    "mcgrievingonly_insult_H9": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "insult"
+        ],
+        "intro": [
+            "[t_c rolls {PRONOUN/t_c/poss} eyes.]"
+        ]
     }
 }

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -10685,11 +10685,10 @@
         },
         "relationship": [
             "min_platonic_50",
-            "from_parent"
+            "from_parent",
+            "from_adopted_parent"
         ],
-        "tags": [
-            "adoptive_parent"
-        ],
+        "tags": [],
         "intro": [
             "y_c, my sweet kit... after you become an apprentice, and start spending all day with your mentor and the other apprentices...",
             "Make sure to come tell me how everything's going. I want to hear about your training, and if anyone's being mean to you, and if you noticed something scary...",
@@ -14589,8 +14588,8 @@
                 "kitten"
             ]
         },
-        "tags": [
-            "grieving_you"
+        "relationship": [
+            "grievingyou"
         ],
         "intro": [
             "What - When did you come back?",
@@ -14850,15 +14849,14 @@
             ],
             "status": [
                 "kitten"
-            ]
+            ],
+            "cluster": ["unruly"]
         },
         "season": [
             "leafbare",
             "newleaf"
         ],
-        "tags": [
-            "unruly"
-        ],
+        "tags": [],
         "intro": [
             "[In the midst of doing your chores for the day, you happen to stumble across t_c causing some trouble.]",
             "[t_c's head pops out of the hole {PRONOUN/t_c/subject} dug, completely covered in mud.]",
@@ -15010,11 +15008,10 @@
         "t_c": {
             "status": [
                 "kitten"
-            ]
+            ],
+            "cluster": ["unruly"]
         },
-        "tags": [
-            "unruly"
-        ],
+        "tags": [],
         "intro": [
             "Hey, I noticed it's been really quiet.",
             "So I stirred up some trouble for you! r_c1 and r_c2 have been mad for hourrrssss!",
@@ -15598,15 +15595,14 @@
         "t_c": {
             "status": [
                 "kitten"
-            ]
+            ],
+            "cluster": ["self-conscious"]
         },
         "relationship": [
             "from_kit",
             "from_adopted_kit"
         ],
-        "tags": [
-            "self-conscious"
-        ],
+        "tags": [],
         "intro": [
             "[You watch t_c as {PRONOUN/t_c/subject} {VERB/t_c/groom/grooms} {PRONOUN/t_c/poss} little paws, love for {PRONOUN/t_c/object} coursing through your body at the sight. Your kit is so cute!]",
             "What? Do I look funny? What's wrong??"
@@ -15773,14 +15769,13 @@
             ],
             "condition": [
                 "blind:any:false"
-            ]
+            ],
+            "cluster": ["self-conscious"]
         },
         "relationship": [
             "min_platonic_25"
         ],
-        "tags": [
-            "self-conscious"
-        ],
+        "tags": [],
         "intro": [
             "Hey, umm... y_c? Can I ask a weird question?",
             "... Do I sneeze funny?",
@@ -15860,9 +15855,8 @@
                 "blind:any:false"
             ]
         },
-        "tags": [
-            "leaf-fall"
-        ],
+        "season": ["leaffall"],
+        "tags": [],
         "intro": [
             "If r_k brings any more leaves into the nursery just because {PRONOUN/r_k/subject} thought they looked pretty, I'm moving my nest outside."
         ]
@@ -16266,11 +16260,10 @@
         "t_c": {
             "status": [
                 "kitten"
-            ]
+            ],
+            "cluster": ["quiet"]
         },
-        "tags": [
-            "quiet"
-        ],
+        "tags": [],
         "intro": [
             "[While sorting through herbs, you glance up to see t_c, observing you from the entrance to the medicine den.]",
             "... I have a thorn stuck behind my ear. Can you pull it out?",
@@ -16374,11 +16367,10 @@
             "condition": [
                 "deaf:any:false"
             ],
-            "shunned": true
+            "shunned": true,
+            "cluster": ["self-conscious"]
         },
-        "tags": [
-            "self-conscious"
-        ],
+        "tags": [],
         "intro": [
             "[t_c huddles off to the side, as though {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} trying to be as inconspicuous as possible.]"
         ]

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -10678,9 +10678,6 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "adoptive_parent"
             ]
         },
         "relationship": [

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -15960,12 +15960,10 @@
             ],
             "condition": [
                 "deaf:any:false"
-            ]
+            ],
+            "cluster": ["quiet"]
         },
-        "tags": [
-            "quiet",
-            "they_living"
-        ],
+        "tags": [],
         "intro": [
             "[t_c gazes at you curiously.]"
         ]
@@ -16066,16 +16064,14 @@
         },
         "t_c": {
             "cluster": [
+                "self-conscious",
                 "shy"
             ],
             "status": [
                 "kitten"
             ]
         },
-        "tags": [
-            "self-conscious",
-            "they_living"
-        ],
+        "tags": [],
         "intro": [
             "Umm...",
             "You're a StarClan cat, right? What are you doing here?",
@@ -16177,9 +16173,7 @@
                 "kitten"
             ]
         },
-        "tags": [
-            "they_living"
-        ],
+        "tags": [],
         "intro": [
             "[Some of the kits, when they see you, react with surprise or confusion - much differently than they do when they see their living Clanmates.]",
             "... What do you want?",

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -13732,6 +13732,9 @@
         "y_c": {
             "condition": [
                 "deaf:any:false"
+            ],
+            "status": [
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -13747,9 +13750,7 @@
             "max_trust_10",
             "max_comfort_15"
         ],
-        "tags": [
-            "you_queen_apprentice"
-        ],
+        "tags": [],
         "intro": [
             "[t_c, unwelcome amongst the other kits in the nursery, is batting at a leaf.]",
             "[You'd never have thought a kit capable of such brutal actions.]",
@@ -13766,7 +13767,8 @@
             ],
             "shunned": true,
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -13784,9 +13786,7 @@
         "relationship": [
             "min_platonic_15"
         ],
-        "tags": [
-            "you_queen_apprentice"
-        ],
+        "tags": [],
         "intro": [
             "How come you're being shunned, anyway?",
             "... You killed a cat?",
@@ -13797,6 +13797,9 @@
     },
     "queenapp_youshunned_kit_pos_rad1": {
         "y_c": {
+            "status": [
+                "queen's apprentice"
+            ],
             "shunned": true
         },
         "t_c": {
@@ -13810,9 +13813,7 @@
         "relationship": [
             "min_platonic_15"
         ],
-        "tags": [
-            "you_queen_apprentice"
-        ],
+        "tags": [],
         "intro": [
             "Why's everycat acting funny around you?",
             "... You killed a cat?",
@@ -15664,7 +15665,8 @@
     "daydreamer_kit_rad1": {
         "y_c": {
             "age": [
-                "adult"
+                "adult",
+                "adolescent"
             ]
         },
         "t_c": {
@@ -15678,9 +15680,7 @@
                 "kitten"
             ]
         },
-        "tags": [
-            "you_adolescent"
-        ],
+        "tags": [],
         "intro": [
             "[You call t_c's name to get {PRONOUN/t_c/poss} attention, but {PRONOUN/t_c/subject} {VERB/t_c/don't/doesn't} react.]",
             "[Nor {VERB/t_c/do/does} {PRONOUN/t_c/subject} react the next five times you say {PRONOUN/t_c/poss} name. {PRONOUN/t_c/subject/CAP} only {VERB/t_c/react/reacts} when you prod {PRONOUN/t_c/object} with your paw.]",
@@ -15871,6 +15871,9 @@
         "y_c": {
             "condition": [
                 "grief stricken"
+            ],
+            "status": [
+                "not_kitten"
             ]
         },
         "t_c": {
@@ -15881,9 +15884,7 @@
                 "kitten"
             ]
         },
-        "tags": [
-            "you_no_kit"
-        ],
+        "tags": [],
         "intro": [
             "[t_c drops a small bundle of flowers at your paws.]",
             "r_q said that sometimes when cats are grieving, putting flowers on the dead cat's grave can help them feel better.",
@@ -16137,7 +16138,11 @@
         ]
     },
     "attention-seeker_kitten_rad1": {
-        "y_c": {},
+        "y_c": {
+            "status": [
+                "not_kitten"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "attention-seeker"
@@ -16146,9 +16151,7 @@
                 "kitten"
             ]
         },
-        "tags": [
-            "you_no_kitten"
-        ],
+        "tags": [],
         "intro": [
             "[t_c has wadded a bunch of old moss together and is embedding sticks into it.]",
             "[Finally, when {PRONOUN/t_c/subject} {VERB/t_c/appear/appears} satisfied with the result, {PRONOUN/t_c/subject} {VERB/t_c/drape/drapes} the moss over {PRONOUN/t_c/poss} back, sticks facing outwards.]",

--- a/resources/dicts/lifegen_talk/kittypet.json
+++ b/resources/dicts/lifegen_talk/kittypet.json
@@ -157,11 +157,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Do you have a family, little one?",
             "Oh... you're one of them. I'm glad you have someone to look out for you."
@@ -172,11 +173,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c visibly flinches when {PRONOUN/t_c/subject} {VERB/t_c/see/sees} you, {PRONOUN/t_c/poss} wispy, otherworldly pelt shaking.]",
             "Oh- a Clancat! I didn't know I was on your territory... or that you could see me.",
@@ -213,11 +215,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Eep!",
             "[t_c startles when you approach, the cat crouching a bit as {PRONOUN/t_c/subject} {VERB/t_c/cower/cowers} away from you.]",
@@ -240,11 +243,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[You go out for a hunting trip, and upon a rock, basking in the early morning sunlight, sits a spirit, purring contently.]",
             "[You move closer, and {PRONOUN/t_c/subject} {VERB/t_c/tilt/tilts} {PRONOUN/t_c/poss} head just enough to catch a glimpse of you, yawning.]",
@@ -273,11 +277,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "You know, the way you Clan cats live your lives is... interesting.",
             "Why not just find some housefolk? They're very nice, and you can enjoy all sorts of things, like warm blankets, free food, and all the cuddles you want.",
@@ -298,12 +303,11 @@
                 "ur"
             ],
             "status": [
-                "kitten"
+                "kitten",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Hi! Um, I think I lost my housefolk. You wouldn't know where they are, would you?",
             "Oh, housefolk are, like, these big cats with no fur, and they walk on their back paws, and they have these big warm dens full of lots of stuff!",
@@ -317,11 +321,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[You find t_c near the Clan border, staring off into the trees.]",
             "Oh! Hi, y_c. I'm just... looking.",
@@ -340,12 +345,11 @@
                 "ur"
             ],
             "status": [
-                "kitten"
+                "kitten",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "y_c! y_c! Look, look, look!",
             "[As soon as {PRONOUN/t_c/subject} {VERB/t_c/catch/catches} sight of you, t_c turns and sprints away. You run to catch up, almost losing {PRONOUN/t_c/poss} translucent pelt in the scenery.]",
@@ -364,11 +368,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c is watching the Thunderpath.]",
             "Sometimes I just sit here and make sure that the cars don't hit any cats.",
@@ -391,11 +396,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[You see a curious t_c peeking {PRONOUN/t_c/poss} head over the border. With a graceful leap, {PRONOUN/t_c/poss} misty paws hit the star-littered ground.]",
             "Oh! Hello there!",
@@ -425,12 +431,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Mewwww...",
             "[Oh! A tiny kittypet kit has wandered to the border you were playing at.]",
@@ -456,12 +461,11 @@
                 "ur"
             ],
             "status": [
-                "newborn"
+                "newborn",
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[You're retrieving a moss-ball from near the border when you notice a newborn kittypet kit with transparent, misty fur that waves softly.]",
             "Mew?",
@@ -482,11 +486,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c approaches you, tail high and eyes bright.]",
             "Hi! What are you doing here? Are you lost?",
@@ -508,11 +513,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "What's on my agenda today... Hm...",
             "Well, I was going to go visit my housefolk, see how they're doing. I think they've been lonely without me bothering them all day, haha! Someone's got to take care of them.",
@@ -532,11 +538,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "I think I'm struggling a bit without the Twolegs that took care of me.",
             "I like to visit them sometimes... I know they can't see me but I'm at peace just watching them go about their lives."
@@ -551,11 +558,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Hello y_c!",
             "Have you seen the new housefolk that moved in to your old home?",
@@ -581,11 +589,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c anxiously surveys your injuries.]",
             "I think my housefolk kept most dangerous stuff away from me. I didn't even realize it at the time.",
@@ -611,11 +620,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "You're really not looking great, y_c. Maybe... maybe you could find a Twoleg to take care of you, just for a bit?",
             "I'm sorry, I know you Clan cats don't like that! It's just... The Twolegs did a lot of scary things, but I think they were trying to help me.",
@@ -639,11 +649,12 @@
             "dead": [
                 "sc",
                 "max_they_deadfor_10"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c looks around, unsure of {PRONOUN/t_c/poss} surroundings.]"
         ]
@@ -660,11 +671,12 @@
             ],
             "dead": [
                 "sc"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "All the cats in here keep talking about 'Clans' and 'StarClan' and the 'Dark Forest'.",
             "I don't understand any of it. I just want to go home."
@@ -686,11 +698,12 @@
             "dead": [
                 "any",
                 "max_they_deadfor_10"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "[t_c looks around, unsure of {PRONOUN/t_c/poss} surroundings.]"
         ]
@@ -707,14 +720,15 @@
             ],
             "dead": [
                 "sc"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "I miss my napping place...",
-            "Don't get me wrong. Everything here is very fluffy. But. Everything is fluffy. I don't know where to lay!"
+            "Don't get me wrong. Everything here is very fluffy. But that's the issue! Everything is fluffy. I don't know where to lay!"
         ]
     },
     "kittypet_sc_H5": {
@@ -729,11 +743,12 @@
             ],
             "dead": [
                 "any"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "I miss napping in the sun. I guess I just miss being alive in general."
         ]

--- a/resources/dicts/lifegen_talk/kittypet.json
+++ b/resources/dicts/lifegen_talk/kittypet.json
@@ -337,7 +337,7 @@
     "dead_kittypet_J6": {
         "y_c": {
             "age": [
-                "not_kit"
+                "not_kitten"
             ]
         },
         "t_c": {

--- a/resources/dicts/lifegen_talk/leader.json
+++ b/resources/dicts/lifegen_talk/leader.json
@@ -34,14 +34,9 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "no_kit"
             ]
         },
-        "tags": [
-            "no_kit"
-        ],
+        "tags": [],
         "intro": [
             "Hey there, y_c. I've heard someone from o_c_n say they've seen you around the borders lately at the last Gathering.",
             "Like, what were you thinking? o_c_n cats could have...",

--- a/resources/dicts/lifegen_talk/loner.json
+++ b/resources/dicts/lifegen_talk/loner.json
@@ -51,11 +51,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "Oh- I haven't seen you before. Did you get lost?",
             "[You finally glance around at your surroundings. Ah, yes, you definitely have gotten yourself lost.]",
@@ -78,11 +79,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "What's your name? y_c? Oh, what a pretty name.",
             "What do you think my name would be if I were a Clan cat?"
@@ -243,11 +245,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "Are you happy in a Clan?",
             "I can't imagine having all of those cats constantly around... especially now that I'm a ghost.",
@@ -272,11 +275,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "Hm.",
             "[You turn around, your fur bristling along your spine. Only to see a nearly transparent, misty cat. t_c.]",
@@ -304,11 +308,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "[Running through the cold shadows that coat the Dark Forest, you stumble back just in time to not run directly into what, at first, seems to be a cloud of mist. Then you realize that it's a cat, but not one from StarClan. Too wispy.]",
             "Oh, little one!",
@@ -333,14 +338,15 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "loner"
             ]
         },
-        "tags": [
-            "they_loner"
-        ],
+        "tags": [],
         "intro": [
             "Still wandering?",
-            "... yeah, me too. I used to wonder what would happen after death. It's boring!"
+            "... Yeah, me too. I used to wonder what would happen after death. It's boring!"
         ]
     }
 }

--- a/resources/dicts/lifegen_talk/mediator apprentice.json
+++ b/resources/dicts/lifegen_talk/mediator apprentice.json
@@ -359,18 +359,13 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "no_kit"
             ]
         },
         "relationship": [
             "min_platonic_20",
             "min_platonic_20"
         ],
-        "tags": [
-            "no_kit"
-        ],
+        "tags": [],
         "intro": [
             "y_c. Buddy. Best friend. We've GOTTA TRY this. r_c told me that if you eat three mice, one rabbit, and howl at the moon, you get magic powers!",
             "What? It's totally real, {PRONOUN/r_c/subject} wouldn't lie to me like that! I prommissseee."
@@ -1097,17 +1092,12 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "no_kit"
             ]
         },
         "relationship": [
             "min_jealousy_50"
         ],
-        "tags": [
-            "no_kit"
-        ],
+        "tags": [],
         "intro": [
             "Hey, so, remember when you cracked that joke today, and everybody laughed, and then I tried to be funny, and no one laughed?",
             "... What was the deal with that?"

--- a/resources/dicts/lifegen_talk/mediator.json
+++ b/resources/dicts/lifegen_talk/mediator.json
@@ -1782,11 +1782,10 @@
         },
         "season": [
             "greenleaf",
-            "newleaf"
+            "newleaf",
+            "leaffall"
         ],
-        "tags": [
-            "leaf-fall"
-        ],
+        "tags": [],
         "intro": [
             "y_c! Your humble Clan mediator, t_c, has a plan, and I need you to help me go through with it!",
             "We've been hunting too much recently, and the prey is starting to dwindle. This could spell the end if we don't let it repopulate - we don't want to worsen leaf-bare, after all.",

--- a/resources/dicts/lifegen_talk/medicine cat apprentice.json
+++ b/resources/dicts/lifegen_talk/medicine cat apprentice.json
@@ -3213,7 +3213,8 @@
     "brooding_toqueen_AJ": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -3231,9 +3232,7 @@
                 "deputy"
             ]
         },
-        "tags": [
-            "you_queen's_aprentice"
-        ],
+        "tags": [],
         "intro": [
             "[The nursery entrance shudders open, revealing little r_k dangling from t_c's mouth, mewling and squirming in protest.]",
             "[t_c sets {PRONOUN/r_k/object} on the ground, and the kit bounds towards you, cowering behind your leg at t_c's cold glare.]",
@@ -3244,7 +3243,8 @@
     "brooding_toqueen_AJ1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -3260,7 +3260,6 @@
             ]
         },
         "tags": [
-            "you_queen's_aprentice",
             "clan_has_kits"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/medicine cat apprentice.json
+++ b/resources/dicts/lifegen_talk/medicine cat apprentice.json
@@ -1152,9 +1152,6 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "connected"
             ]
         },
         "tags": [
@@ -1180,9 +1177,6 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "connected"
             ]
         },
         "tags": [
@@ -1302,13 +1296,10 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "min_plat_35"
             ]
         },
-        "tags": [
-            "min_plat_35"
+        "relationship": [
+            "min_platonic_35"
         ],
         "intro": [
             "[t_c hurries a bundle of herbs into the medicine den, brow furrowed and ears pinned back in concentration.]",
@@ -1324,14 +1315,12 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "min_plat_35",
-                "connected"
             ]
         },
+        "relationship": [
+            "min_platonic_35"
+        ],
         "tags": [
-            "min_plat_35",
             "connected"
         ],
         "intro": [
@@ -1720,9 +1709,6 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "clan_has_kits"
             ]
         },
         "tags": [
@@ -2769,8 +2755,7 @@
                 "min_they_deadfor_40"
             ],
             "status": [
-                "medicine cat",
-                "connected"
+                "medicine cat"
             ]
         },
         "tags": [
@@ -2805,8 +2790,7 @@
                 "min_they_deadfor_40"
             ],
             "status": [
-                "medicine cat",
-                "connected"
+                "medicine cat"
             ]
         },
         "tags": [

--- a/resources/dicts/lifegen_talk/medicine cat apprentice.json
+++ b/resources/dicts/lifegen_talk/medicine cat apprentice.json
@@ -3791,7 +3791,7 @@
             ],
             "status": [
                 "medicine cat",
-                "they_medicine_cat_apprentince"
+                "medicine cat apprentice"
             ],
             "age": [
                 "not_kitten"
@@ -3800,9 +3800,7 @@
                 "INNOVATOR,1"
             ]
         },
-        "tags": [
-            "they_medicine_cat_apprentince"
-        ],
+        "tags": [],
         "intro": [
             "[You make your way into the medicine den to find that t_c is building some sort of contraption around the herb stock.]",
             "Hi, y_c. What do you need?",

--- a/resources/dicts/lifegen_talk/medicine cat.json
+++ b/resources/dicts/lifegen_talk/medicine cat.json
@@ -3087,7 +3087,10 @@
     },
     "medshunned_H2": {
         "y_c": {
-            "shunned": true
+            "shunned": true,
+            "condition": [
+                "illness:any"
+            ]
         },
         "t_c": {
             "shunned": true,
@@ -3101,9 +3104,7 @@
         "relationship": [
             "min_platonic_50"
         ],
-        "tags": [
-            "you_sick"
-        ],
+        "tags": [],
         "intro": [
             "[t_c curls around your sickly body, protecting you from the stares and judgment from the rest of the clan.]",
             "Don't worry. If any of them come close, I'll protect you.",
@@ -3112,7 +3113,10 @@
     },
     "medshunned_H3": {
         "y_c": {
-            "shunned": true
+            "shunned": true,
+            "condition": [
+                "illness:any"
+            ]
         },
         "t_c": {
             "shunned": true,
@@ -3124,9 +3128,7 @@
         "relationship": [
             "min_dislike_50"
         ],
-        "tags": [
-            "you_sick"
-        ],
+        "tags": [],
         "intro": [
             "[t_c reluctantly shoves a few herbs into your paws, looking away.]",
             "Stop. Don't say anything. I may dislike you, but it really pains me to see you suffer.",
@@ -4421,7 +4423,8 @@
     "brooding_toqueen_AJ": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -4439,9 +4442,7 @@
                 "deputy"
             ]
         },
-        "tags": [
-            "you_queen's_aprentice"
-        ],
+        "tags": [],
         "intro": [
             "[The nursery entrance shudders open, revealing little r_k dangling from t_c's mouth, mewling and squirming in protest.]",
             "[t_c sets {PRONOUN/r_k/object} on the ground, and the kit bounds towards you, cowering behind your leg at t_c's cold glare.]",
@@ -4452,7 +4453,8 @@
     "brooding_toqueen_AJ1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -4468,7 +4470,6 @@
             ]
         },
         "tags": [
-            "you_queen's_aprentice",
             "clan_has_kits"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/medicine cat.json
+++ b/resources/dicts/lifegen_talk/medicine cat.json
@@ -5209,7 +5209,8 @@
                 "silly"
             ],
             "status": [
-                "medicine cat"
+                "medicine cat",
+                "medicine cat apprentice"
             ],
             "age": [
                 "not_kitten"
@@ -5218,9 +5219,7 @@
                 "INNOVATOR,1"
             ]
         },
-        "tags": [
-            "they_medicine_cat_apprentince"
-        ],
+        "tags": [],
         "intro": [
             "[You make your way into the medicine den to find that t_c is building some sort of contraption around the herb stock.]",
             "Hi, y_c. What do you need?",

--- a/resources/dicts/lifegen_talk/medicine cat.json
+++ b/resources/dicts/lifegen_talk/medicine cat.json
@@ -580,9 +580,6 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "connected"
             ]
         },
         "tags": [
@@ -608,9 +605,6 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "connected"
             ]
         },
         "tags": [
@@ -778,13 +772,10 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "min_plat_35"
             ]
         },
         "tags": [
-            "min_plat_35"
+            "min_platonic_35"
         ],
         "intro": [
             "[t_c hurries a bundle of herbs into the medicine den, brow furrowed and ears pinned back in concentration.]",
@@ -800,14 +791,10 @@
             ],
             "condition": [
                 "blind:any:false"
-            ],
-            "status": [
-                "min_plat_35",
-                "connected"
             ]
         },
         "tags": [
-            "min_plat_35",
+            "min_platonic_35",
             "connected"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -3908,7 +3908,8 @@
         "y_c": {
             "condition": [
                 "blind:any:false",
-                "deaf:any:false"
+                "deaf:any:false",
+                "guilt"
             ],
             "shunned": true
         },
@@ -3922,12 +3923,10 @@
             ]
         },
         "relationship": [
-            "from_your_kit"
+            "from_kit",
+            "from_adopted_kit"
         ],
-        "tags": [
-            "from_your_adopted_kit",
-            "you_guilty"
-        ],
+        "tags": [],
         "intro": [
             "[Every time t_c shifts ever so slightly away from you, you're struck with a pang of terror.]",
             "[It almost feels as though t_c, despite being a newborn, already knows <i>exactly</i> what you did.]"

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -3894,11 +3894,10 @@
             ]
         },
         "relationship": [
-            "from_your_kit"
-        ],
-        "tags": [
+            "from_your_kit",
             "from_your_adopted_kit"
         ],
+        "tags": [],
         "intro": [
             "[t_c's sides rise and fall as {PRONOUN/t_c/subject} {VERB/t_c/nestle/nestles} against you.]",
             "[As you watch t_c sleep, you find yourself hoping that {PRONOUN/t_c/subject} {VERB/t_c/don't/doesn't} make the same mistakes you did.]"

--- a/resources/dicts/lifegen_talk/newborn.json
+++ b/resources/dicts/lifegen_talk/newborn.json
@@ -4005,5 +4005,67 @@
             "[As you watch t_c flop around like a fish out of water, you can't help but think of yg_c.]",
             "[Even the most ridiculously random things remind you of {PRONOUN/yg_c/object}.]"
         ]
+    },
+    "scnew_urnew_R1": {
+        "y_c": {
+            "status": [
+                "newborn"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "dead": [
+                "sc"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "dead": [
+                "ur"
+            ],
+            "status": [
+                "newborn"
+            ]
+        },
+        "tags": [],
+        "intro": [
+            "Meewwww!",
+            "[Oh? Who is that? You toddle closer curiously.]",
+            "Meeew mew.",
+            "[You're friends now. The day is spent napping together.]"
+        ]
+    },
+    "scnew_urnew_R3": {
+        "y_c": {
+            "status": [
+                "newborn"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "dead": [
+                "sc"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "dead": [
+                "ur"
+            ],
+            "status": [
+                "newborn"
+            ]
+        },
+        "tags": [],
+        "intro": [
+            "Mew! Mew! Mew! Mew!",
+            "[What's that sound?]",
+            "Mew! Meeew! Meeeew! Meeeew!",
+            "[You decide to mew back, and soon there is a volley of tiny squeaks echoing softly between the two of you.]"
+        ]
     }
 }

--- a/resources/dicts/lifegen_talk/queen's apprentice.json
+++ b/resources/dicts/lifegen_talk/queen's apprentice.json
@@ -1645,15 +1645,14 @@
         },
         "t_c": {
             "cluster": [
-                "sweet"
+                "sweet",
+                "sensitive"
             ],
             "status": [
                 "queen's apprentice"
             ]
         },
-        "tags": [
-            "sensitive"
-        ],
+        "tags": [],
         "intro": [
             "[You're up late. It's a beautiful night in c_n and you wanted to see the stars.]",
             "[Surprisingly, you were not alone. You exited the camp to spot t_c, sobbing to {PRONOUN/t_c/self}.]",

--- a/resources/dicts/lifegen_talk/queen's apprentice.json
+++ b/resources/dicts/lifegen_talk/queen's apprentice.json
@@ -2319,7 +2319,7 @@
             ],
             "shunned": true,
             "status": [
-                "they_queen_apprentice"
+                "queen's apprentice"
             ]
         },
         "relationship": [
@@ -2327,9 +2327,7 @@
             "max_trust_10",
             "from_your_apprentice"
         ],
-        "tags": [
-            "they_queen_apprentice"
-        ],
+        "tags": [],
         "intro": [
             "[You shoo t_c away from the nursery with a pang of guilt in your heart.]",
             "[{PRONOUN/t_c/subject/CAP}{VERB/t_c/'re/'s} always so good with the kits, and you can't imagine {PRONOUN/t_c/object} doing anything to them.]",

--- a/resources/dicts/lifegen_talk/queen.json
+++ b/resources/dicts/lifegen_talk/queen.json
@@ -1682,9 +1682,6 @@
             ],
             "age": [
                 "not_kitten"
-            ],
-            "status": [
-                "clan_has_kits"
             ]
         },
         "tags": [
@@ -3163,7 +3160,7 @@
             ]
         },
         "relationship": [
-            "min_trust_50",
+            "min_trust_20",
             "from_mentor"
         ],
         "tags": [

--- a/resources/dicts/lifegen_talk/rogue.json
+++ b/resources/dicts/lifegen_talk/rogue.json
@@ -50,11 +50,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "[You aren't surprised to see t_c at the border. Again.]",
             "Your kind can't just claim all of the territory!",
@@ -78,11 +79,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "[You feel eyes peering at you from the fog, wandering near the border of stars and mist.]",
             "[Briefly, you spot the ghost of a rogue, looking at your star-sewn pelt in awe.]",
@@ -101,11 +103,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "Hello?",
             "[You turn to see an unfamiliar cat, standing half-in and half-out of the fog.]",
@@ -122,11 +125,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "[You find yourself a little lost, stumbling around the mist trying to find your way out.]",
             "This way.",
@@ -151,11 +155,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "What was my name?",
             "t_c. It meant a lot to me, even though it wasn't as grand as a Clancat's.",
@@ -303,11 +308,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "[You leave the camp to stretch your legs, and run into a strange spirit.]",
             "Hey you! This is my territory!",
@@ -334,11 +340,12 @@
             ],
             "age": [
                 "not_kitten"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "I fought you. I fought you and your <i>Clan</i>. You took our food, our shelter...",
             "Why would I want to talk to you after that?"
@@ -357,14 +364,15 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
         "relationship": [
             "from_parent"
         ],
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "Hpf.",
             "Look at you unfortunate morsel.",
@@ -382,11 +390,12 @@
         "t_c": {
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "Well, well. Look who we have here!",
             "It's a little Clan cat, being all brave.",
@@ -462,11 +471,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "We may be dead, but I still expect you to respect my territory."
         ]
@@ -486,11 +496,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "rogue"
             ]
         },
-        "tags": [
-            "they_rogue"
-        ],
+        "tags": [],
         "intro": [
             "Cross that line, and you cross <i>me</i>."
         ]

--- a/resources/dicts/lifegen_talk/rogue.json
+++ b/resources/dicts/lifegen_talk/rogue.json
@@ -411,11 +411,12 @@
             ],
             "dead": [
                 "ur"
+            ],
+            "status": [
+                "kittypet"
             ]
         },
-        "tags": [
-            "they_kittypet"
-        ],
+        "tags": [],
         "intro": [
             "Do you have a family, little one?",
             "Oh... you're one of them. I'm glad you have someone to look out for you."

--- a/resources/dicts/lifegen_talk/warrior.json
+++ b/resources/dicts/lifegen_talk/warrior.json
@@ -5289,7 +5289,11 @@
         ]
     },
     "Introspective_mentor_H1": {
-        "y_c": {},
+        "y_c": {
+            "status": [
+                "apprentice"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "introspective"
@@ -5302,9 +5306,7 @@
             "min_platonic_50",
             "from_mentor"
         ],
-        "tags": [
-            "you_apprentince"
-        ],
+        "tags": [],
         "intro": [
             "[t_c has had you training ever since sunrise but today you just can't get your pounce right. Eyes filled with frustrated tears, you try again... But fail.]",
             "Chin up, let me help. All it takes is practice. You're allowed mistakes because that's how we learn.",
@@ -5314,7 +5316,11 @@
         ]
     },
     "Introspective_mentor_H2": {
-        "y_c": {},
+        "y_c": {
+            "status": [
+                "apprentice"
+            ]
+        },
         "t_c": {
             "cluster": [
                 "brooding",
@@ -5328,9 +5334,7 @@
             "min_dislike_50",
             "from_mentor"
         ],
-        "tags": [
-            "you_apprentince"
-        ],
+        "tags": [],
         "intro": [
             "[t_c has been quiet these past few moons, {PRONOUN/t_c/poss} eyes filled with an emotion you can't explain. Not yet, anyway.]",
             "We're training in the rain today. Come, y_c.",
@@ -8383,7 +8387,8 @@
     "brooding_toqueen_AJ": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -8401,9 +8406,7 @@
                 "deputy"
             ]
         },
-        "tags": [
-            "you_queen's_aprentice"
-        ],
+        "tags": [],
         "intro": [
             "[The nursery entrance shudders open, revealing little r_k dangling from t_c's mouth, mewling and squirming in protest.]",
             "[t_c sets {PRONOUN/r_k/object} on the ground, and the kit bounds towards you, cowering behind your leg at t_c's cold glare.]",
@@ -8414,7 +8417,8 @@
     "brooding_toqueen_AJ1": {
         "y_c": {
             "status": [
-                "queen"
+                "queen",
+                "queen's apprentice"
             ]
         },
         "t_c": {
@@ -8430,7 +8434,6 @@
             ]
         },
         "tags": [
-            "you_queen's_aprentice",
             "clan_has_kits"
         ],
         "intro": [

--- a/resources/dicts/lifegen_talk/warrior.json
+++ b/resources/dicts/lifegen_talk/warrior.json
@@ -529,9 +529,7 @@
         "relationship": [
             "min_platonic_50"
         ],
-        "tags": [
-            "no_kit"
-        ],
+        "tags": [],
         "intro": [
             "Huh? Oh, nothing's wrong ...",
             "Just ... had a bad day, is all ...",

--- a/resources/dicts/relationship_events/normal_interactions/dislike/decrease.json
+++ b/resources/dicts/relationship_events/normal_interactions/dislike/decrease.json
@@ -47,7 +47,7 @@
 			"m_c tries to find r_c to apologize for something, but finds {PRONOUN/r_c/object} playing with a Clanmate.",
 			"r_c does something endearing, which surprises m_c.",
 			"m_c stumbles upon r_c looking at the stars with wonder in {PRONOUN/r_c/poss} eyes.",
-			"m_c is rethinking how {PRONOUN/m_c/subject} feel about r_c and gives {PRONOUN/r_c/object} another chance.",
+			"m_c is rethinking how {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} about r_c and gives {PRONOUN/r_c/object} another chance.",
 			"m_c and r_c apologized over something petty they both did to each other.",
 			"m_c realizes {PRONOUN/m_c/subject} {VERB/m_c/were/was} being childish and apologizes to r_c for {PRONOUN/m_c/poss} behavior."
 		]

--- a/resources/dicts/thoughts/dead/unknownresidence/former_Clancat.json
+++ b/resources/dicts/thoughts/dead/unknownresidence/former_Clancat.json
@@ -3,7 +3,7 @@
         "id": "general_formerclancat_dead_thoughts",
         "thoughts": [
             "Wanders around {PRONOUN/m_c/poss} old territory",
-            "Explores places {PRONOUN/m_c/subject} {VERB/m_c/were/was} afraid to go in life",
+            "Explores places {PRONOUN/m_c/subject} {VERB/m_c/were/was} afraid to go to in life",
             "Hunts for prey, despite not feeling hungry",
             "Watches {PRONOUN/m_c/poss} old Clanmates"
         ],

--- a/resources/dicts/thoughts/dead/unknownresidence/loner.json
+++ b/resources/dicts/thoughts/dead/unknownresidence/loner.json
@@ -4,7 +4,7 @@
         "thoughts": [
             "Wanders around {PRONOUN/m_c/poss} old territory",
             "Catches sight of Clan cats near {PRONOUN/m_c/poss} old territory",
-            "Explores places {PRONOUN/m_c/subject} {VERB/m_c/were/was} afraid to go in life",
+            "Explores places {PRONOUN/m_c/subject} {VERB/m_c/were/was} afraid to go to in life",
             "Hunts for prey, despite not feeling hungry"
         ],
         "main_status_constraint": [


### PR DESCRIPTION
This PR is me manually going through the dialogue tags to make sure everything is placed where it's supposed to be. 

Includes:
- Moving incorrectly placed tags in either status or relationship into "tags" - they should now hopefully be available
- Got rid of you_df_trainee, a tag that is no longer valid. Switched with "status": ["df_trainee"]
- Got rid of any they_/you_ (outside of the family relations) tagging, since none of those exist anymore
- Relationship tags incorrectly placed in "tags"
- Status tags incorrectly placed in "tags" or "relationship"
- Retagged some flirts that should have had "non-mates", condition tags, or "reject"/"accept" tags
- "adoptive_parent" -> "adopted_parent"
- Small dialogue fixes