### PR TITLE
7.6.3 fixes

### DIFF
--- a/resources/dicts/lifegen_talk/choice_dialogue.json
+++ b/resources/dicts/lifegen_talk/choice_dialogue.json
@@ -1976,15 +1976,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Labor pains",
+                "text": "Labor pains.",
                 "next_scene": "labor_pains"
             },
             "choice2": {
-                "text": "Milk production",
+                "text": "Milk production.",
                 "next_scene": "milk_production"
             },
             "choice3": {
-                "text": "Nausea",
+                "text": "Nausea.",
                 "next_scene": "nausea"
             }
         },
@@ -2072,15 +2072,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Cobwebs and chervil",
+                "text": "Cobwebs and chervil.",
                 "next_scene": "cobwebs_chervil"
             },
             "choice2": {
-                "text": "Yarrow",
+                "text": "Yarrow.",
                 "next_scene": "yarrow"
             },
             "choice3": {
-                "text": "Cobwebs and comfrey",
+                "text": "Cobwebs and comfrey.",
                 "next_scene": "cobwebs_comfrey"
             }
         },
@@ -2121,7 +2121,7 @@
                 "next_scene": "help_socialize"
             },
             "choice2": {
-                "text": "[Leave {PRONOUN/t_c/object} alone]",
+                "text": "[Leave {PRONOUN/t_c/object} alone.]",
                 "next_scene": "leave_alone"
             }
         },
@@ -2362,11 +2362,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Comfort]",
+                "text": "[Comfort.]",
                 "next_scene": "comfort"
             },
             "choice2": {
-                "text": "[Leave Alone]",
+                "text": "[Leave alone.]",
                 "next_scene": "leave_alone"
             }
         },
@@ -2408,15 +2408,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Comfort]",
+                "text": "[Comfort.]",
                 "next_scene": "comfort"
             },
             "choice2": {
-                "text": "[Confidently reassure]",
+                "text": "[Confidently reassure.]",
                 "next_scene": "confidently_reassure"
             },
             "choice3": {
-                "text": "[Criticize]",
+                "text": "[Criticize.]",
                 "next_scene": "criticize"
             }
         },
@@ -2523,11 +2523,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Praise your apprentice]",
+                "text": "[Praise your apprentice.]",
                 "next_scene": "praise_apprentice"
             },
             "choice2": {
-                "text": "[Scold your apprentice]",
+                "text": "[Scold your apprentice.]",
                 "next_scene": "scold_apprentice"
             }
         },
@@ -2626,11 +2626,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },
@@ -2848,15 +2848,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Doe eyes]",
+                "text": "[Doe eyes.]",
                 "next_scene": "doe"
             },
             "choice2": {
-                "text": "[War face]",
+                "text": "[War face.]",
                 "next_scene": "war"
             },
             "choice3": {
-                "text": "[Squint]",
+                "text": "[Squint.]",
                 "next_scene": "war"
             }
         },
@@ -3448,11 +3448,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Maybe",
+                "text": "Maybe.",
                 "next_scene": "shunnedmate_maybe"
             },
             "choice2": {
-                "text": "I don't think so",
+                "text": "I don't think so.",
                 "next_scene": "shunnedmate_no"
             }
         },
@@ -3484,11 +3484,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Stop them]",
+                "text": "[Stop them.]",
                 "next_scene": "shunnedtalk_stop"
             },
             "choice2": {
-                "text": "[Let them be]",
+                "text": "[Let them be.]",
                 "next_scene": "shunnedtalk_allow"
             }
         },
@@ -3525,11 +3525,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "somethingbad_yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "somethingbad_no"
             }
         },
@@ -3574,11 +3574,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "leaderagain_yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "leaderagain_no"
             }
         },
@@ -3830,19 +3830,19 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "The Clan's leader",
+                "text": "The Clan's leader.",
                 "next_scene": "growup_leader"
             },
             "choice2": {
-                "text": "A warrior",
+                "text": "A warrior.",
                 "next_scene": "growup_warrior"
             },
             "choice3": {
-                "text": "A medicine cat",
+                "text": "A medicine cat.",
                 "next_scene": "growup_medcat"
             },
             "choice4": {
-                "text": "I don't know",
+                "text": "I don't know.",
                 "next_scene": "growup_idk"
             }
         },
@@ -3896,19 +3896,19 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "The Clan's leader",
+                "text": "The Clan's leader.",
                 "next_scene": "growup_leader"
             },
             "choice2": {
-                "text": "A warrior",
+                "text": "A warrior.",
                 "next_scene": "growup_warrior"
             },
             "choice3": {
-                "text": "A medicine cat",
+                "text": "A medicine cat.",
                 "next_scene": "growup_medcat"
             },
             "choice4": {
-                "text": "I don't know",
+                "text": "I don't know.",
                 "next_scene": "growup_idk"
             }
         },
@@ -3951,20 +3951,20 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "I do",
+                "text": "I do.",
                 "next_scene": "regret_ido"
             },
             "choice2": {
-                "text": "I don't",
+                "text": "I don't.",
                 "next_scene": "regret_idont"
             }
         },
-        "I do": [
+        "regret_ido": [
             "I see... Some advice to you then? Work for forgiveness and don't give up. Show them you deserve a second chance.",
             "Everycat makes mistakes sometimes. You don't need to explain that to anyone either. Just do your best from now on.",
             "You only live once after all. Make the most of it. And if you end up here in the end... It was still worth a try, right?"
         ],
-        "I don't": [
+        "regret_idont": [
             "No shame in that at all. Respectable choice, really.",
             "Just don't get caught if you do it again. I'd hate to see you kicked out for something like this. Those star-blind fools will know in the end...",
             "But what your Clanmates don't know in life won't hurt them."
@@ -4136,15 +4136,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Attack t_c]",
+                "text": "[Attack t_c.]",
                 "next_scene": "attack"
             },
             "choice2": {
-                "text": "[Tattle on t_c]",
+                "text": "[Tattle on t_c.]",
                 "next_scene": "tattle"
             },
             "choice3": {
-                "text": "[Leave t_c alone]",
+                "text": "[Leave t_c alone.]",
                 "next_scene": "leave"
             }
         },
@@ -4212,11 +4212,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Intervene]",
+                "text": "[Intervene.]",
                 "next_scene": "intervene"
             },
             "choice2": {
-                "text": "[Let {PRONOUN/t_c/object} be]",
+                "text": "[Let {PRONOUN/t_c/object} be.]",
                 "next_scene": "leave"
             }
         },
@@ -4271,11 +4271,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Get someone else to help]",
+                "text": "[Get someone else to help.]",
                 "next_scene": "other"
             },
             "choice2": {
-                "text": "[Leave {PRONOUN/t_c/object} alone]",
+                "text": "[Leave {PRONOUN/t_c/object} alone.]",
                 "next_scene": "leave"
             }
         },
@@ -4317,15 +4317,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Get someone else to help]",
+                "text": "[Get someone else to help.]",
                 "next_scene": "other"
             },
             "choice2": {
-                "text": "[Leave {PRONOUN/t_c/object} alone]",
+                "text": "[Leave {PRONOUN/t_c/object} alone.]",
                 "next_scene": "leave"
             },
             "choice3": {
-                "text": "[Talk to t_c yourself]",
+                "text": "[Talk to t_c yourself.]",
                 "next_scene": "help"
             }
         },
@@ -4426,15 +4426,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Tease t_c]",
+                "text": "[Tease t_c.]",
                 "next_scene": "tease"
             },
             "choice2": {
-                "text": "[Crack t_c's shell]",
+                "text": "[Crack t_c's shell.]",
                 "next_scene": "compliment"
             },
             "choice3": {
-                "text": "[Leave t_c alone]",
+                "text": "[Leave t_c alone.]",
                 "next_scene": "leave"
             }
         },
@@ -4539,15 +4539,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Compliment t_c]",
+                "text": "[Compliment t_c.]",
                 "next_scene": "compliment"
             },
             "choice2": {
-                "text": "[Tease t_c]",
+                "text": "[Tease t_c.]",
                 "next_scene": "tease"
             },
             "choice3": {
-                "text": "[Keep it professional]",
+                "text": "[Keep it professional.]",
                 "next_scene": "profesh"
             }
         },
@@ -4590,11 +4590,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },
@@ -4635,11 +4635,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Get up]",
+                "text": "[Get up.]",
                 "next_scene": "rise"
             },
             "choice2": {
-                "text": "[Keep sleeping]",
+                "text": "[Keep sleeping.]",
                 "next_scene": "sleep"
             }
         },
@@ -4678,11 +4678,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },
@@ -5082,7 +5082,7 @@
             "Really? But they were so sure... They told so many stories...",
             "S-sorry. I think I'm going to go now."
         ],
-        "shrug": [
+        "smile": [
             "[You smile, showing your teeth. The cat jumps away.]",
             "O-okay! Sorry for asking! I got lost, I swear, I didn't mean to be here!",
             "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/run/runs}, leaving a trail of misty pawprints.]"

--- a/resources/dicts/lifegen_talk/focuses/halloween.json
+++ b/resources/dicts/lifegen_talk/focuses/halloween.json
@@ -30,11 +30,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "scare_yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "scare_no"
             }
         },
@@ -208,11 +208,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Prey",
+                "text": "Prey.",
                 "next_scene": "prey"
             },
             "choice2": {
-                "text": "Prank",
+                "text": "Prank.",
                 "next_scene": "prank"
             }
         },
@@ -257,11 +257,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Run away",
+                "text": "[Run away.]",
                 "next_scene": "run"
             },
             "choice2": {
-                "text": "Let them",
+                "text": "[Let them.]",
                 "next_scene": "accept"
             }
         },
@@ -275,11 +275,11 @@
         ],
         "run_choices": {
             "choice1": {
-                "text": "Still refuse",
+                "text": "[Still refuse.]",
                 "next_scene": "refuse"
             },
             "choice2": {
-                "text": "Relent",
+                "text": "[Relent.]",
                 "next_scene": "accept"
             }
         },
@@ -289,11 +289,11 @@
         ],
         "accept_choices": {
             "choice1": {
-                "text": "Deer",
+                "text": "Deer.",
                 "next_scene": "costume"
             },
             "choice2": {
-                "text": "Bunny",
+                "text": "Bunny.",
                 "next_scene": "costume"
             }
         },

--- a/resources/dicts/lifegen_talk/focuses/unknown_murder.json
+++ b/resources/dicts/lifegen_talk/focuses/unknown_murder.json
@@ -2,14 +2,8 @@
     "unkmurder_J1": {
         "y_c": {
             "status": [
-                "warrior",
-                "queen",
-                "medicine cat",
-                "mediator",
-                "apprentice",
-                "mediator apprentice",
-                "mediator apprentice",
-                "queen's apprentice"
+                "not_leader",
+                "not_deputy"
             ],
             "age": [
                 "not_kitten"
@@ -23,14 +17,8 @@
                 "silly"
             ],
             "status": [
-                "warrior",
-                "queen",
-                "medicine cat",
-                "mediator",
-                "apprentice",
-                "mediator apprentice",
-                "mediator apprentice",
-                "queen's apprentice"
+                "not_leader",
+                "not_deputy"
             ],
             "age": [
                 "not_kitten"
@@ -52,15 +40,15 @@
                 "next_scene": "idontknow"
             },
             "choice2": {
-                "text": "dislike-r_w1",
+                "text": "dislike-r_w1.",
                 "next_scene": "dislike_r_w1"
             },
             "choice3": {
-                "text": "r_w2-neurotic",
+                "text": "r_w2-neurotic.",
                 "next_scene": "r_w2_neurotic"
             },
             "choice4": {
-                "text": "l_n",
+                "text": "l_n.",
                 "next_scene": "l_n"
             }
         },
@@ -1699,14 +1687,8 @@
     "unknown_murder_J2": {
         "y_c": {
             "status": [
-                "warrior",
-                "queen",
-                "medicine cat",
-                "mediator",
-                "apprentice",
-                "mediator apprentice",
-                "mediator apprentice",
-                "queen's apprentice"
+                "not_leader",
+                "not_deputy"
             ],
             "age": [
                 "not_kitten"
@@ -1721,14 +1703,8 @@
                 "silly"
             ],
             "status": [
-                "warrior",
-                "queen",
-                "medicine cat",
-                "mediator",
-                "apprentice",
-                "mediator apprentice",
-                "mediator apprentice",
-                "queen's apprentice"
+                "not_leader",
+                "not_deputy"
             ],
             "age": [
                 "not_kitten"
@@ -1750,15 +1726,15 @@
                 "next_scene": "idontknow"
             },
             "choice2": {
-                "text": "dislike-r_w1",
+                "text": "dislike-r_w1.",
                 "next_scene": "dislike_r_w1"
             },
             "choice3": {
-                "text": "r_w2-neurotic",
+                "text": "r_w2-neurotic.",
                 "next_scene": "r_w2_neurotic"
             },
             "choice4": {
-                "text": "l_n",
+                "text": "l_n.",
                 "next_scene": "l_n"
             }
         },
@@ -1934,11 +1910,11 @@
                 "next_scene": "didyou"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "killthem_no"
             },
             "choice3": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "killthem_yes"
             }
         },
@@ -2780,11 +2756,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "I promise",
+                "text": "I promise.",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },

--- a/resources/dicts/lifegen_talk/focuses/war.json
+++ b/resources/dicts/lifegen_talk/focuses/war.json
@@ -2055,11 +2055,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Object]",
+                "text": "[Object.]",
                 "next_scene": "object"
             },
             "choice2": {
-                "text": "[Agree]",
+                "text": "[Agree.]",
                 "next_scene": "agree"
             }
         },

--- a/resources/dicts/lifegen_talk/general_no_kit.json
+++ b/resources/dicts/lifegen_talk/general_no_kit.json
@@ -35750,11 +35750,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Wake {PRONOUN/t_c/object} up",
+                "text": "[Wake {PRONOUN/t_c/object} up.]",
                 "next_scene": "wake"
             },
             "choice2": {
-                "text": "Let {PRONOUN/t_c/object} sleep",
+                "text": "[Let {PRONOUN/t_c/object} sleep.]",
                 "next_scene": "sleep"
             }
         },
@@ -35901,7 +35901,7 @@
                 "next_scene": "withme"
             },
             "choice2": {
-                "text": "Ignore them.",
+                "text": "[Ignore them.]",
                 "next_scene": "ignore"
             },
             "choice3": {
@@ -38728,7 +38728,7 @@
                 "next_scene": "shunned_revenge"
             },
             "choice2": {
-                "text": "Impulsive.",
+                "text": "Impulse.",
                 "next_scene": "shunned_impulsive"
             },
             "choice3": {
@@ -39089,10 +39089,6 @@
             "l_n said you did really bad things and I shouldn't talk with you anymore.",
             "Is it true? Did you do something? I know it's serious enough for l_n to tell me personally."
         ],
-        "intro_text": [
-            "l_n said you did really bad things and I shouldn't talk with you anymore.",
-            "Is it true? Did you do something? I know it's serious enough for l_n to tell me personally."
-        ],
         "intro_choices": {
             "choice1": {
                 "text": "[Tell the truth.]",
@@ -39385,9 +39381,6 @@
             "not_accomplice"
         ],
         "intro": [
-            "I'm mad at you."
-        ],
-        "intro_text": [
             "I'm mad at you."
         ],
         "intro_choices": {

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -2387,7 +2387,8 @@
             ]
         },
         "relationship": [
-            "min_platonic_20"
+            "min_platonic_20",
+            "non-related"
         ],
         "intro": [
             "What do you need?",
@@ -10004,7 +10005,7 @@
     "intro": [
        "[d_n and l_n are talking with an unfamiliar cat by l_n's den. You sneak closer to hear what they're saying, but are scooped up by t_c.]",
        "Don't eavesdrop, y_c. And that conversation isn't for kits' ears, anyhow.",
-       "[t_c takes you back to the nursery and blocks your further escape attempts. {PRONOUN/t_c/subject/CAP}{VERB/t_c/'re/'s} no fun..."
+       "[t_c takes you back to the nursery and blocks your further escape attempts. {PRONOUN/t_c/subject/CAP}{VERB/t_c/'re/'s} no fun...]"
 ]
 },
 

--- a/resources/dicts/lifegen_talk/general_you_kit.json
+++ b/resources/dicts/lifegen_talk/general_you_kit.json
@@ -9667,11 +9667,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "real"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "not_real"
             }
         },

--- a/resources/dicts/lifegen_talk/kitten.json
+++ b/resources/dicts/lifegen_talk/kitten.json
@@ -9638,11 +9638,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "showaround_yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "showaround_no"
             }
         },
@@ -9695,15 +9695,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "The black roses",
+                "text": "The black roses.",
                 "next_scene": "blackroses"
             },
             "choice2": {
-                "text": "The blue lillies",
+                "text": "The blue lillies.",
                 "next_scene": "bluelilles"
             },
             "choice3": {
-                "text": "The yellow tulips",
+                "text": "The yellow tulips.",
                 "next_scene": "yellowtulips"
             }
         },
@@ -9788,15 +9788,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Sometimes",
+                "text": "Sometimes.",
                 "next_scene": "df_nice_sometimes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "df_nice_no"
             },
             "choice3": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "df_nice_yes"
             }
         },
@@ -10424,7 +10424,7 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Sure",
+                "text": "Sure.",
                 "next_scene": "sure"
             },
             "choice2": {
@@ -11037,11 +11037,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Explain what you did",
+                "text": "[Explain what you did.]",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },
@@ -11080,11 +11080,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Explain what you did",
+                "text": "[Explain what you did.]",
                 "next_scene": "yes"
             },
             "choice2": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "no"
             }
         },
@@ -14670,11 +14670,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "But you're always the clancat.",
+                "text": "But you're always the Clancat.",
                 "next_scene": "always_clancat"
             },
             "choice2": {
-                "text": "But I wanna be the clancat!",
+                "text": "But I wanna be the Clancat!",
                 "next_scene": "wanna_be_clancat"
             },
             "choice3": {
@@ -15369,11 +15369,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "join_no"
             },
             "choice2": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "join_yes"
             }
         },
@@ -16186,11 +16186,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Run",
+                "text": "Run.",
                 "next_scene": "run"
             },
             "choice2": {
-                "text": "Stay where you are",
+                "text": "Stay where you are.",
                 "next_scene": "stay"
             }
         },
@@ -16510,7 +16510,7 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Yes!.]",
+                "text": "[Yes!]",
                 "next_scene": "yes"
             },
             "choice2": {
@@ -16568,11 +16568,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Refuse",
+                "text": "Refuse.",
                 "next_scene": "refuse"
             },
             "choice2": {
-                "text": "Help hide",
+                "text": "Help hide.",
                 "next_scene": "help"
             }
         },

--- a/resources/dicts/lifegen_talk/leader.json
+++ b/resources/dicts/lifegen_talk/leader.json
@@ -4454,15 +4454,15 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Shush {PRONOUN/t_c/object}",
+                "text": "[Shush {PRONOUN/t_c/object}.]",
                 "next_scene": "shush"
             },
             "choice2": {
-                "text": "Agree",
+                "text": "[Agree.]",
                 "next_scene": "agree"
             },
             "choice3": {
-                "text": "Deny",
+                "text": "[Deny.]",
                 "next_scene": "deny"
             }
         },
@@ -4482,11 +4482,11 @@
         ],
         "deny_choices": {
             "choice1": {
-                "text": "Relent",
+                "text": "[Relent.]",
                 "next_scene": "agree"
             },
             "choice2": {
-                "text": "Keep denying",
+                "text": "[Keep denying.]",
                 "next_scene": "no_fun"
             }
         },

--- a/resources/dicts/lifegen_talk/queen's apprentice.json
+++ b/resources/dicts/lifegen_talk/queen's apprentice.json
@@ -2391,10 +2391,6 @@
             "... y_c?",
             "[t_c's unsure voice is heard from behind you. {PRONOUN/t_c/subject/CAP} awkwardly {VERB/t_c/shift/shifts} {PRONOUN/t_c/poss} paws as {PRONOUN/t_c/subject} {VERB/t_c/work/works} up the courage to speak to you.]"
         ],
-        "intro_text": [
-            "... y_c?",
-            "[t_c's unsure voice is heard from behind you. {PRONOUN/t_c/subject/CAP} awkwardly {VERB/t_c/shift/shifts} {PRONOUN/t_c/poss} paws as {PRONOUN/t_c/subject} {VERB/t_c/work/works} up the courage to speak to you.]"
-        ],
         "intro_choices": {
             "choice1": {
                 "text": "You're not supposed to talk to me.",

--- a/resources/dicts/lifegen_talk/queen.json
+++ b/resources/dicts/lifegen_talk/queen.json
@@ -3425,23 +3425,23 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "Prey",
+                "text": "Prey.",
                 "next_scene": "wrong"
             },
             "choice2": {
-                "text": "Kit",
+                "text": "Kit.",
                 "next_scene": "wrong"
             },
             "choice3": {
-                "text": "Monster",
+                "text": "Monster.",
                 "next_scene": "wrong"
             },
             "choice4": {
-                "text": "Dirtplace",
+                "text": "Dirtplace.",
                 "next_scene": "right"
             },
             "choice5": {
-                "text": "t_c",
+                "text": "t_c.",
                 "next_scene": "flatter"
             }
         },
@@ -4144,11 +4144,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "No",
+                "text": "No.",
                 "next_scene": "kits_no"
             },
             "choice2": {
-                "text": "Yes",
+                "text": "Yes.",
                 "next_scene": "kits_yes"
             }
         },

--- a/resources/dicts/lifegen_talk/warrior.json
+++ b/resources/dicts/lifegen_talk/warrior.json
@@ -8303,11 +8303,11 @@
         ],
         "intro_choices": {
             "choice1": {
-                "text": "[Ask t_c what's wrong]",
+                "text": "[Ask t_c what's wrong.]",
                 "next_scene": "ask"
             },
             "choice2": {
-                "text": "[Leave t_c alone]",
+                "text": "[Leave t_c alone.]",
                 "next_scene": "leave"
             }
         },

--- a/resources/dicts/thoughts/alive/mediator.json
+++ b/resources/dicts/thoughts/alive/mediator.json
@@ -254,7 +254,7 @@
     {
         "id": "mediator_to_queen",
         "thoughts": [
-            "Offers r_c a space in {PRONOUN/m_c/poss} den so r_c can have so time away from the noisy kittens",
+            "Offers r_c a space in {PRONOUN/m_c/poss} den so r_c can have some time away from the noisy kittens",
             "Asks how r_c is doing after seeing {PRONOUN/r_c/object} become overwhelmed with unruly kittens",
             "Offers to take some of r_c's chores",
             "Complains with r_c about unnecessary arguments while sunbathing",


### PR DESCRIPTION
- Cleans some choice dialogue text to have periods or surrounding brackets. ("no" > "No." / "Refuse" > "[Refuse.]")
- Crash "refuse_idont" fix - choice scene text used the button text instead lol
- Deleted some "intro_text" things in dialogue