### PR TITLE
Bug Fixes!

### DIFF
--- a/resources/lang/en/lifegen_talk/flirt.json
+++ b/resources/lang/en/lifegen_talk/flirt.json
@@ -23,10 +23,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Er, sorry, y_c ... But I don't see you that way."
@@ -59,6 +62,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh, you meant that in, like, a 'best friends' way ... right?"
         ]
@@ -90,6 +96,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ehh ... Good one, bestie! Heh ..."
         ]
@@ -116,6 +125,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Oh... I didn't know you... saw me that way."
@@ -152,6 +164,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh wow, that was funny!",
             "You're such a good friend."
@@ -174,6 +189,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, honey ...",
             "That was... pretty terrible.",
@@ -211,6 +229,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, I... already like someone else?"
         ]
@@ -232,6 +253,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Huh? Oh, um... Thank you? *Snrk*"
         ]
@@ -254,6 +278,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "That's... nice of you to say."
         ]
@@ -277,6 +304,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Haha! That's the funniest joke I've heard all season!"
         ]
@@ -299,6 +329,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "...That's a joke, right?"
         ]
@@ -323,6 +356,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You've got to be joking."
         ]
@@ -344,6 +380,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Eh, hehehe ... Might wanna rethink that one a little y_c."
         ]
@@ -365,6 +404,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Whatever."
         ]
@@ -388,6 +430,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... Is that the best you could do?"
         ]
@@ -409,6 +454,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Stop that, it's not getting you anywhere."
         ]
@@ -430,6 +478,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "What is it going to take in order for you to leave me alone?"
         ]
@@ -452,6 +503,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Congratulations, y_c!",
             "That might just be the worst attempt at flirting I've heard in moons!"
@@ -475,6 +529,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... Okay?"
         ]
@@ -511,6 +568,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... Ew."
         ]
@@ -545,6 +605,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Ew. No."
@@ -582,6 +645,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not a chance in StarClan."
         ]
@@ -604,6 +670,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I think StarClan gave me an omen warning me about this."
         ]
@@ -627,6 +696,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You are <i>so</i> not my type."
         ]
@@ -649,6 +721,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... y_c, was that supposed to be an insult, or an attempt at flirting?",
             "Sorry, I genuinely can't tell."
@@ -685,6 +760,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um... No. You're not even on my playing field."
         ]
@@ -720,6 +798,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ew. I'm too good for you..."
         ]
@@ -754,6 +835,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, but I just don't see how this factors into my 20-moon plan."
         ]
@@ -778,6 +862,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... What are you trying to do?"
         ]
@@ -812,6 +899,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I think I'd rather take my chances with a Dark Forest cat."
         ]
@@ -843,6 +933,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hehe! That was so funny, y_c!",
             "This is why you're one of my closest friends."
@@ -865,6 +958,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... Are you trying to start a fight?"
         ]
@@ -886,6 +982,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um, was that sarcasm?"
         ]
@@ -909,6 +1008,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "...No. I'm sorry but just... no."
         ]
@@ -946,6 +1048,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh- me? Sorry, you aren't exactly my type..."
         ]
@@ -970,6 +1075,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um... no."
         ]
@@ -1000,10 +1108,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "max_like_-50"
+                    "min_dislike_50",
+                    "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Don't talk to me."
@@ -1028,6 +1139,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Just...no."
         ]
@@ -1052,6 +1166,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uhm, I'd rather... not."
         ]
@@ -1082,6 +1199,9 @@
                     "strangers"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Do I know you?"
@@ -1114,6 +1234,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh, what's your name again?"
         ]
@@ -1140,6 +1263,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ahahahahahaha! That was too good!",
             "Wait, wait, stay right there! r_c:0, get over here! Listen to what y_c just said!"
@@ -1162,6 +1288,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, uh I'm sorry, but I think I have to go..."
         ]
@@ -1184,6 +1313,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "...",
             "...",
@@ -1221,6 +1353,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um, what made you think I'd ever say yes?"
         ]
@@ -1243,6 +1378,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "*Snrk* Did a badger teach you how to flirt?"
         ]
@@ -1264,6 +1402,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Stop."
         ]
@@ -1285,6 +1426,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You're... you're kidding, right?"
         ]
@@ -1320,6 +1464,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You're delusional if you think you're good enough for me."
         ]
@@ -1341,6 +1488,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh! Um, I'm gonna go..."
         ]
@@ -1359,6 +1509,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, I... just remembered something I have to do. Bye."
         ]
@@ -1382,6 +1535,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... What's that supposed to mean?"
         ]
@@ -1405,10 +1561,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_50"
+                    "min_like_50",
+                    "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Sorry, but I just see us as friends."
@@ -1432,6 +1591,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh dear. Let me teach you how to flirt."
         ]
@@ -1456,6 +1618,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh... sorry, but that was... horrible."
         ]
@@ -1475,6 +1640,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... You've got a little something on your face..."
         ]
@@ -1496,6 +1664,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ugh... I'm not that shallow."
         ]
@@ -1529,6 +1700,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Frankly, I'd rather eat all our Clan's dirt left in the dirtplace."
@@ -1564,6 +1738,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hmph. Not interested."
         ]
@@ -1585,6 +1762,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um ... oof, this is awkward.",
             "Tell you what, y_c. I'll do us both a favor and pretend this never happened. M'kay?"
@@ -1607,6 +1787,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Aww, isn't that cute?",
             "*Snrk*"
@@ -1644,6 +1827,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Okay, I'm gonna stop you right there. I can see what you're doing and I'll save you the embarrassment in two simple words:",
@@ -1689,6 +1875,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh ... hehe! How sweet of you.",
             "I'll be sure to tell that one to my mate later. {PRONOUN/r_c:0/subject/CAP}'ll definitely love it.",
@@ -1726,6 +1915,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hehe. Thanks, cutie. But I just don't like you like that.",
             "Hey, keep your chin up, though. Plenty of other cats in the Clan who might catch your interest."
@@ -1749,6 +1941,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, dear ... Um, why don't you just stick to admiring me from afar?"
         ]
@@ -1787,6 +1982,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hahaha! That one got me laughing!",
             "As if we'd actually get together ... could you imagine?",
@@ -1812,6 +2010,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... For your own sake, I better have misheard you."
         ]
@@ -1843,10 +2044,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Aw, bestie! That's sweet, but no. My heart belongs to another."
@@ -1882,6 +2086,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... You don't wanna be with a cat like me. Trust me."
         ]
@@ -1904,6 +2111,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Woah... Your breath stinks..."
         ]
@@ -1927,6 +2137,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Eh ... Have you washed today..?"
         ]
@@ -1961,6 +2174,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I'm sorry, y_c... We just ain't got that chemistry, you feel me?"
@@ -1999,6 +2215,9 @@
                     "min_like_20"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Ha! Very funny y_c!",
@@ -2121,6 +2340,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "If I act like I'm interested will it get you to stop?"
         ]
@@ -2176,6 +2398,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "As much as I like you, we have got to work on your flirting ability, dear."
@@ -2434,6 +2659,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "No."
         ]
@@ -2494,6 +2722,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uhm. Why?"
         ]
@@ -2571,6 +2802,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Do you think I'm so shallow ...?"
         ]
@@ -2585,6 +2819,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c narrows {PRONOUN/t_c/poss} eyes suspiciously.]",
             "What's your angle?"
@@ -2626,6 +2863,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Uhm ... Have you considered seeing r_c:0?",
@@ -2708,6 +2948,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Echh. Someone get r_c:0. That was so sincere, I think it's causing an allergic reaction."
         ]
@@ -2729,6 +2972,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Cute. Can I go now?"
         ]
@@ -2755,6 +3001,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hey, r_c:0? Remind me how you teach the kits to spell 'Out of your league'?"
         ]
@@ -2864,6 +3113,9 @@
                     "min_like_30"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Hey, didn't I teach you that line?"
@@ -3294,6 +3546,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I always look lovely. Are you trying to imply that I don't?"
         ]
@@ -3352,6 +3607,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... That was an awful attempt at flirting, but you are cute, so I'll let it slide."
         ]
@@ -3428,6 +3686,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... Hahaha! At least you're funny."
         ]
@@ -3450,6 +3711,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, I just don't have time for something like this right now."
         ]
@@ -3504,6 +3768,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "..Thanks.. Your pelt looks... scruffy today?"
         ]
@@ -3825,6 +4092,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I must have sand in my ears... What was that again?"
         ]
@@ -3959,6 +4229,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "...",
             "Okay then. Thanks, I guess."
@@ -4165,7 +4438,7 @@
                 ],
                 "relationship": [
                     "mates",
-                    "min_like_-25"
+                    "max_dislike_25"
                 ]
             }
         ],
@@ -4205,6 +4478,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Thanks, honey. That was really cute even though it was kind of lame..."
         ]
@@ -4240,6 +4516,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Don't worry! You'll get better one day."
@@ -4313,6 +4592,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "You really suck at that, you know? Hah."
@@ -4573,6 +4855,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time or the place. Move along."
         ]
@@ -4620,6 +4905,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "That's cool, but I've got other things on my mind."
         ]
@@ -4693,6 +4981,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Kind words, but I'm walking a solitary path for now."
         ]
@@ -4730,6 +5021,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Why now? Why me?"
         ]
@@ -4766,6 +5060,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Trust is earned. Let's keep things as they are."
@@ -4849,6 +5146,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ew. Why would you say that to anycat, given your situation?",
             "Murderers don't get love, y_c. Stop trying."
@@ -4873,6 +5173,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Please don't say that to me right now."
         ]
@@ -5038,10 +5341,13 @@
                 ],
                 "relationship": [
                     "non-mates",
-                    "min_romance_10",
-                    "max_like_-25"
+                    "min_dislike_25",
+                    "min_romance_10"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Maybe I could have liked you if you weren't so evil."
@@ -5194,6 +5500,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ugh... Not now..."
         ]
@@ -5215,6 +5524,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ugh..."
         ]
@@ -5236,6 +5548,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ugh..."
         ]
@@ -5269,6 +5584,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c frowns at you, {PRONOUN/t_c/poss} claws pressing out.]",
             "You're not supposed to be talking to me, nevermind saying stupid things like that."
@@ -5305,6 +5623,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "No.",
@@ -5357,6 +5678,9 @@
         "recent_murder": {
             "victim": "r_c:0"
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[You approached t_c, quietly starting to flirt with {PRONOUN/t_c/object}.]",
             "y_c. I murdered r_c:0. Why are you talking to me, let alone like this?",
@@ -5391,13 +5715,16 @@
                 ],
                 "relationship": [
                     "non-mates",
-                    "max_like_-10"
+                    "min_dislike_10"
                 ]
             }
         ],
         "recent_murder": {
             "victim": "r_c:0"
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[You decide to start flirting with t_c in an attempt to see where it leads. {PRONOUN/t_c/subject/CAP} {VERB/t_c/do/does} not seem amused.]",
             "y_c. I murdered r_c:0. I'm not afraid to go after you too if you keep at it.",
@@ -5431,6 +5758,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c backs away, {PRONOUN/t_c/poss} fur bristling.]",
             "You aren't allowed to <i>talk</i> to me, let alone say something like that.",
@@ -5455,6 +5785,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Ugh..."
         ]
@@ -5524,6 +5857,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time, y_c."
         ]
@@ -5549,6 +5885,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Um... no."
         ]
@@ -5655,9 +5994,12 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-10"
+                    "min_dislike_10"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c stares as you for a second, {PRONOUN/t_c/poss} tail lashing.]",
@@ -5734,6 +6076,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c barely looks up at you, choking out a sob as {PRONOUN/t_c/subject} {VERB/t_c/tremble/trembles}.]",
             "y_c, y_c I'm sorry. I- <i>hic</i> I can't...",
@@ -5760,6 +6105,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Right now, my emotions are too raw for anything more."
         ]
@@ -5784,6 +6132,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I need some time to heal. Please understand."
         ]
@@ -5809,6 +6160,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Now's not a good time for me. I hope you get that."
         ]
@@ -5851,6 +6205,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time or the place. Move along."
         ]
@@ -5875,6 +6232,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Well, that's just what I needed. More complicated feelings!"
         ]
@@ -5899,6 +6259,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Why now? Why me?"
         ]
@@ -5948,6 +6311,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
             "How <b>dare</b> you y_c. How dare you think you can replace r_c:0!"
@@ -5973,6 +6339,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Right now, my emotions are too raw for anything more."
         ]
@@ -5998,6 +6367,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I need some time to heal. Please understand."
         ]
@@ -6024,6 +6396,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Now's not a good time for me. I hope you get that."
         ]
@@ -6068,6 +6443,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time or the place. Move along."
         ]
@@ -6093,6 +6471,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Well, that's just what I needed. More complicated feelings!"
         ]
@@ -6118,6 +6499,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Why now? Why me?"
         ]
@@ -6168,6 +6552,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
             "How <b>dare</b> you y_c. How dare you think you can replace r_c:0!"
@@ -6213,6 +6600,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time or the place. Move along."
         ]
@@ -6257,6 +6647,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Not the time or the place. Move along."
         ]
@@ -6323,6 +6716,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I must be going insane. y_c is dead... {PRONOUN/y_c/subject} would never say that..."
         ]
@@ -6386,6 +6782,9 @@
                     "dead/grieving"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "You're not thinking clearly right now..."
@@ -6569,6 +6968,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I don't know what's going on anymore."
         ]
@@ -6606,6 +7008,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I don't know what's going on anymore."
         ]
@@ -6642,6 +7047,9 @@
                     "grieving/dead"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I don't know what's going on anymore."
@@ -6683,6 +7091,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I don't know what's going on anymore."
         ]
@@ -6706,6 +7117,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Absolutely not, y_c. Neither of us are in any state for this. Especially you."
         ]
@@ -6785,6 +7199,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Do you have a death wish, or is this just to humiliate me?"
         ]
@@ -6815,6 +7232,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Get lost, I'm serious.",
             "[t_c hisses in your direction, {PRONOUN/t_c/poss} tail lashing and claws extending.]"
@@ -6837,6 +7257,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You're going to get in trouble, you know that."
         ]
@@ -6871,6 +7294,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I'm a murderer and you're still trying to get with me?",
             "You have some dedication.",
@@ -6894,6 +7320,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You know, I would be flattered if there was some freshkill sent my way.",
             "... No? Then you're not worth my time."
@@ -6982,6 +7411,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I cannot deal with this. Not while my life crumbles so quickly.",
             "... Is this my karma?"
@@ -7029,6 +7461,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c hisses at you.]",
             "I'm not even allowed to talk with r_c:0.",
@@ -7052,6 +7487,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You must be a fool to believe I would take kindly to that.",
             "Scram."
@@ -7074,6 +7512,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I'd consider this an insult."
         ]
@@ -7111,6 +7552,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "r_c:0 just died and you're trying to flirt with me?",
             "... You need to get your priorities in order, y_c. Seriously."
@@ -7132,6 +7576,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
             "[Your flirting is not welcome, it seems.]"
@@ -7152,6 +7599,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c rolls {PRONOUN/t_c/poss} eyes and scoffs.]",
             "Words said so often that they lack any meaning."
@@ -7167,6 +7617,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c shrinks back. {PRONOUN/t_c/subject/CAP} {VERB/t_c/narrow/narrows} {PRONOUN/t_c/poss} eyes at {PRONOUN/t_c/poss} paws.]",
             "Are you making fun of me? That's not nice, y_c."
@@ -7342,6 +7795,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, wrap it up."
         ]
@@ -7372,6 +7828,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "No, thanks."
@@ -7404,6 +7863,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... And what am I supposed to do with this information, exactly?"
         ]
@@ -7434,6 +7896,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "... Right, that made no sense.",
@@ -7477,6 +7942,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Uh, sorry I think I just heard r_c:0 calling for me.",
             "Time to do my duties! Haha... ha...",
@@ -7498,6 +7966,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hm? What?",
             "Sorry, I couldn't hear you."
@@ -7533,6 +8004,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "What are you doing outside? It's so cold!",
             "[t_c coaxes you back to somewhere warm. Alas, your attempt at flirting either went over {PRONOUN/t_c/poss} head... or was ignored.]",
@@ -7560,6 +8034,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
             "[Your flirting is not welcome, it seems.]"
@@ -7579,6 +8056,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You have some nerve..."
         ]
@@ -7605,6 +8085,9 @@
                     "grieving/dead"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I don't understand how you can flirt with me right now!",
@@ -7648,6 +8131,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[While laying next to t_c in camp, you reach your paw towards {PRONOUN/t_c/inposs}.]",
             "[{PRONOUN/t_c/subject/CAP} quickly {VERB/t_c/flinch/flinches} and {VERB/t_c/shuffle/shuffles} away from you.]"
@@ -7715,8 +8201,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "min_romance_20",
-                    "max_like_-20"
+                    "min_dislike_20",
+                    "min_romance_20"
                 ]
             }
         ],
@@ -7864,8 +8350,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "mates",
-                    "min_romance_20"
+                    "min_romance_20",
+                    "mates"
                 ]
             },
             {
@@ -7905,6 +8391,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, y_c! Thank you! Do you know who else has gorgeous eyes?",
             "r_c:0!~",
@@ -7940,6 +8429,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh, I wish r_c:0 spoke to me like that!"
         ]
@@ -7972,6 +8464,9 @@
                     "not_mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "You're really nice, y_c, but...",
@@ -8014,6 +8509,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, y_c but... I have my eyes set out for r_c:0."
         ]
@@ -8044,9 +8542,12 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-50"
+                    "min_dislike_50"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I would rather chew on ragwort than flirt with you."
@@ -8083,6 +8584,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I'm really busy with the kits right now, sorry! I'll talk to you later?"
         ]
@@ -8104,6 +8608,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "... This is a weird way to ask for mediation."
         ]
@@ -8143,9 +8650,12 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-50"
+                    "min_dislike_50"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "StarClan, do I need to ask r_c:0 to set me out on more patrols so you'll stop flirting with me?"
@@ -8190,6 +8700,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "That was a nice attempt, but I am very happy with r_c:0."
         ]
@@ -8218,8 +8731,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             },
             {
@@ -8233,6 +8746,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c laughs loudly at your flirting.]",
@@ -8278,6 +8794,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Are you joking? You must be joking.",
             "... you know I'm happily in a relationship with r_c:0... right?"
@@ -8307,8 +8826,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "max_like_-30"
+                    "min_dislike_30",
+                    "non-mates"
                 ]
             },
             {
@@ -8322,6 +8841,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Back off before I call r_c:0 over."
@@ -8351,8 +8873,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "max_like_-30"
+                    "min_dislike_30",
+                    "non-mates"
                 ]
             },
             {
@@ -8366,6 +8888,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c hisses at you, unamused with your flirting.]",
@@ -8399,6 +8924,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Sorry, you're definitely not my type of cat."
         ]
@@ -8429,6 +8957,9 @@
                     "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "What?",
@@ -8470,6 +9001,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Look, y_c, do you not see how happy I am with r_c:0?",
@@ -8515,6 +9049,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh uh, I just remembered that I need to do something!",
             "With r_c:0, yup!",
@@ -8541,9 +9078,12 @@
                 ],
                 "relationship": [
                     "non-mates",
-                    "max_like_-10"
+                    "min_dislike_10"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c narrows {PRONOUN/t_c/poss} eyes at you, thoughtful.]",
@@ -8578,6 +9118,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I'm sorry, y_c, I'm... not in the mood right now."
@@ -8641,6 +9184,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c smiles at you, but it's clear {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} not in the mood for flirting.]"
         ]
@@ -8661,6 +9207,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c curls in a ball, ignoring your attempts to flirt.]"
         ]
@@ -8692,6 +9241,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "y_c, I'm not in the mood."
         ]
@@ -8722,6 +9274,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "y_c... is it just me or did your flirting become worse over the moons we've been together?",
@@ -8755,6 +9310,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You must not mean that."
         ]
@@ -8785,6 +9343,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Awh! I can tell you've been... practicing that one!",
@@ -8819,6 +9380,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I'm going to be honest.",
             "That was the worst, y_c."
@@ -8843,6 +9407,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c curls in a ball, ignoring your attempts to flirt.]"
         ]
@@ -8897,6 +9464,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Ah... I'm not feeling well right now, y_c.",
@@ -8992,6 +9562,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c frowns a little at your flirting attempt. {PRONOUN/t_c/subject/CAP} {VERB/t_c/turn/turns} away without a response.]"
         ]
@@ -9010,6 +9583,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem to know how to respond.]"
         ]
@@ -9218,8 +9794,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9259,8 +9835,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_50"
+                    "min_like_50",
+                    "non-mates"
                 ]
             }
         ],
@@ -9300,9 +9876,9 @@
                     "y_c"
                 ],
                 "relationship": [
+                    "min_like_50",
                     "min_romance_10",
-                    "non-mates",
-                    "min_like_50"
+                    "non-mates"
                 ]
             }
         ],
@@ -9346,8 +9922,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_30"
+                    "min_like_30",
+                    "non-mates"
                 ]
             }
         ],
@@ -9382,8 +9958,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_40"
+                    "min_like_40",
+                    "non-mates"
                 ]
             },
             {
@@ -9437,8 +10013,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9482,8 +10058,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_30"
+                    "min_like_30",
+                    "non-mates"
                 ]
             }
         ],
@@ -9524,9 +10100,9 @@
                     "y_c"
                 ],
                 "relationship": [
+                    "min_like_50",
                     "min_romance_20",
-                    "non-mates",
-                    "min_like_50"
+                    "non-mates"
                 ]
             }
         ],
@@ -9736,8 +10312,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9775,8 +10351,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9811,8 +10387,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9846,8 +10422,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_20"
+                    "min_like_20",
+                    "non-mates"
                 ]
             }
         ],
@@ -9881,8 +10457,8 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "min_like_50"
+                    "min_like_50",
+                    "non-mates"
                 ]
             }
         ],
@@ -10092,7 +10668,7 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "min_like_-5"
+                    "max_dislike_5"
                 ]
             }
         ],
@@ -10128,7 +10704,7 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "min_like_-5"
+                    "max_dislike_5"
                 ]
             }
         ],
@@ -10169,6 +10745,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Oh! Um...",
             "[t_c freezes, casting {PRONOUN/t_c/poss} gaze around camp.]",
@@ -10195,6 +10774,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
         ]
@@ -10239,6 +10821,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
         ]
@@ -10299,6 +10884,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
         ]
@@ -10347,6 +10935,9 @@
                 "cat": "t_c"
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Umm....",
             "I'm getting very mixed signals from you lately, y_c."
@@ -10414,6 +11005,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Hm? Are you really bored enough to try hitting on me?",
             "Yeesh. There's gotta be better things for you to do. Go try drawing in the dirt, or something. I'm not that desperate yet."
@@ -10448,6 +11042,9 @@
                     "strangers"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "I don't find murderers very attractive, y_c. Sorry."
@@ -10518,6 +11115,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You take 'heartstopper' both literally and figuratively, huh?"
         ]
@@ -10547,6 +11147,9 @@
                 "success": true
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I agreed to be your partner in crime, not your partner in life."
         ]
@@ -10565,6 +11168,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c stares at you in confusion.]",
             "You have a <i>weird</i> way of trying to flatter me."
@@ -10597,9 +11203,12 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-30"
+                    "min_dislike_30"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c recoils with a hiss.]"
@@ -10633,10 +11242,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "mates",
-                    "max_like_25"
+                    "max_like_25",
+                    "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c blatantly ignores you, barely even twitching an ear as {PRONOUN/t_c/subject} {VERB/t_c/pad/pads} by.]",
@@ -10673,6 +11285,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "There's a time and a place, y_c. This isn't either of those."
         ]
@@ -10697,6 +11312,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c looks away, but {PRONOUN/t_c/poss} face clearly reveals {PRONOUN/t_c/poss} discomfort.]",
             "[... Not the reaction you'd hoped for.]"
@@ -10722,6 +11340,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "...",
             "[Judging by the lengthy pause, you suspect t_c feels extremely uncomfortable.]",
@@ -10748,6 +11369,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c backs away, eyes averted.]"
         ]
@@ -10772,6 +11396,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c stares at you blankly.]"
         ]
@@ -10796,6 +11423,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c looks at you uncertainly, as though {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} hoping you aren't serious.]"
         ]
@@ -10829,6 +11459,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c's eyes are fixed on r_c:0 across camp.]",
             "... Oh, sorry, y_c! What were you saying?"
@@ -10857,6 +11490,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[As you and t_c are sharing tongues, you nervously shift to press yourself against {PRONOUN/t_c/subject} pelt.]",
             "[t_c stiffens, then pulls away.]",
@@ -10883,6 +11519,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[After what feels like moons of working up the courage, you gingerly run your tail over t_c's shoulders.]",
             "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/jerk/jerks} away sharply, leaving your entire pelt burning with embarrassment.]"
@@ -10906,6 +11545,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c seems too fixated on a stick to even notice you.]"
         ]
@@ -10940,6 +11582,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[You press against t_c. {PRONOUN/t_c/subject/CAP} {VERB/t_c/keep/keeps} {PRONOUN/t_c/poss} eyes closed, but press back against you.]",
@@ -10976,6 +11621,9 @@
                     "mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "[t_c lifts {PRONOUN/t_c/poss} head to look at you. {PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} initially react to your signs, so you try again.]",
@@ -11041,6 +11689,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c turns {PRONOUN/t_c/poss} head away and lashes {PRONOUN/t_c/poss} tail.]",
             "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem impressed.]"
@@ -11073,10 +11724,13 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "non-mates",
-                    "max_like_-10"
+                    "min_dislike_10",
+                    "non-mates"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Go away!"
@@ -11100,6 +11754,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I do not want to speak with you right now, y_c.",
             "Please, leave me to grieve."
@@ -11120,6 +11777,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "I do not want to speak with you right now, y_c.",
             "Please, leave me to grieve."
@@ -11155,6 +11815,9 @@
                     "grieving/dead"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Don't you think you have caused me enough suffering? I do not need your awful flirting on top of it."
@@ -11196,6 +11859,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
             "[It's not the time for flirting.]"
@@ -11229,6 +11895,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
             "[It's not the time for flirting.]"
@@ -11261,7 +11930,7 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-40"
+                    "min_dislike_40"
                 ]
             }
         ],
@@ -11336,6 +12005,9 @@
             },
             "t_c": {}
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Has anycat ever told you to look ugly when you cry?"
         ]
@@ -11359,6 +12031,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Are you using flirting as a coping mechanism?"
         ]
@@ -11391,6 +12066,9 @@
                     "min_like_20"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Hey, uh, sorry, but I think you should be reflecting in your feelings before flirting with anycat. You know, think about yourself first."
@@ -11451,7 +12129,7 @@
                     "y_c"
                 ],
                 "relationship": [
-                    "max_like_-25"
+                    "min_dislike_25"
                 ]
             },
             {
@@ -11560,6 +12238,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c shuffles their paws, not meeting your eyes.]",
             "[It doesn't feel entirely appropriate to accept your advances, not when you're missing r_c:0 so much.]"
@@ -11638,6 +12319,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "Now is not the time, y_c..."
         ]
@@ -11667,6 +12351,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c avoids your flirting by sitting with {PRONOUN/t_c/poss} back facing you.]"
         ]
@@ -11739,6 +12426,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c smiles, but {PRONOUN/t_c/subject} {VERB/t_c/look/looks} a little awkward around the eyes.]"
         ]
@@ -11763,6 +12453,9 @@
                 ]
             }
         },
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "[t_c ignores you with a flick of {PRONOUN/t_c/poss} tail.]"
         ]
@@ -11800,6 +12493,9 @@
                 ]
             }
         ],
+        "tags": [
+            "reject"
+        ],
         "intro": [
             "You're not real, you're not real, you're not real."
         ]
@@ -11831,6 +12527,9 @@
                     "grieving/dead"
                 ]
             }
+        ],
+        "tags": [
+            "reject"
         ],
         "intro": [
             "Is my mind playing tricks on me?"

--- a/resources/lang/en/lifegen_talk/general_no_kit.json
+++ b/resources/lang/en/lifegen_talk/general_no_kit.json
@@ -66578,12 +66578,7 @@
                     "y_c"
                 ],
                 "accessory": [
-                    "CYANBOW",
-                    "LIMEBOW",
-                    "WHITEBOW",
-                    "PINKBOW",
-                    "CRIMSONBOW",
-                    "RAINBOWBOW"
+                    "COLLAR"
                 ],
                 "addition": "choice"
             }

--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -331,7 +331,7 @@ class Status:
         """
         Returns True if the cat is currently part of the same group as your cat
         """
-        if not game.clan.your_cat or not game.clan:
+        if not game.clan.your_cat or not game.clan or (game.clan.your_cat and game.clan.your_cat.dead):
             return self.alive_in_player_clan
         # this fails tests bc it checks this before Clan exists
         # so... nonecheck failsafe
@@ -861,23 +861,26 @@ class Status:
         LIFEGEN: Gets the heading text for the game based on the group you're currently in
         """
         heading_text = "DebugClan"
-        if game.clan.your_cat.status.group.is_any_clan_group():
-            if game.clan.your_cat.status.group_ID == CatGroup.PLAYER_CLAN_ID:
-                heading_text = f"{game.clan.displayname}Clan"
-            else:
-                your_clan = None
-                for other_clan in game.clan.all_other_clans:
-                    if other_clan.group_ID == game.clan.your_cat.status.group_ID:
-                        your_clan = other_clan
-                if your_clan:
-                    heading_text = f"{your_clan.name}Clan"
-                else:
-                    print("LG WARNING: Can't find your cat's group!")
+        if not game.clan.your_cat.dead:
+            if game.clan.your_cat.status.group.is_any_clan_group():
+                if game.clan.your_cat.status.group_ID == CatGroup.PLAYER_CLAN_ID:
                     heading_text = f"{game.clan.displayname}Clan"
-        elif game.clan.your_cat.status.group:
-            heading_text = f"The {(game.clan.your_cat.status.group).capitalize().replace('_', ' ')}"
+                else:
+                    your_clan = None
+                    for other_clan in game.clan.all_other_clans:
+                        if other_clan.group_ID == game.clan.your_cat.status.group_ID:
+                            your_clan = other_clan
+                    if your_clan:
+                        heading_text = f"{your_clan.name}Clan"
+                    else:
+                        print("LG WARNING: Can't find your cat's group!")
+                        heading_text = f"{game.clan.displayname}Clan"
+            elif game.clan.your_cat.status.group:
+                heading_text = f"The {(game.clan.your_cat.status.group).capitalize().replace('_', ' ')}"
+            else:
+                heading_text = "Outside the Clan"
         else:
-            heading_text = "Outside the Clan"
+            heading_text = f"{game.clan.displayname}Clan"
 
         return heading_text
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1481,9 +1481,15 @@ def generate_lifegen_events():
             clan=game.clan,
             other_clan=random.choice(game.clan.all_other_clans)
             )
-        
-        possible_events.append([processed_text, event["types"], involved_cats])
-            
+
+        possible_events.append(
+            [
+                processed_text,
+                event["types"],
+                involved_cats
+            ]
+        )
+   
     # except Exception as e:
     #     print("ERROR Generating LifeGen Events:", e)
 
@@ -1494,14 +1500,13 @@ def generate_lifegen_events():
     for i in range(random.randint(0,5)):
         chosen_type = random.choice(possible_types)
         events_for_type = [
-            event[0] for event in possible_events if
+            event for event in possible_events if
             chosen_type in event[1]
         ]
         if not events_for_type:
             continue
-        print("Generating", chosen_type, "event.")
         chosen_event = random.choice(events_for_type)
-        game.cur_events_list.insert(0, Single_Event(chosen_event, "alert", chosen_event[1]))
+        game.cur_events_list.insert(0, Single_Event(chosen_event[0], "alert", chosen_event[2]))
 
         
 def generate_kit_events():

--- a/scripts/events_module/dialogue/dialogue.py
+++ b/scripts/events_module/dialogue/dialogue.py
@@ -6,6 +6,7 @@ from scripts.game_structure.game.switches import switch_get_value, Switch
 from scripts.game_structure.localization import load_lang_resource
 from scripts.cat.enums import CatRank, CatAge
 from scripts.cat.cats import Cat
+from scripts.cat.pelts import Pelt
 from scripts.events_module.consequences import unpack_rel_block
 
 
@@ -120,7 +121,6 @@ class Dialogue():
         for key, block in possible_texts.items():
             if "season" in block:
                 if (
-                    block["season"] and
                     game.clan.current_season not in block["season"] and
                     game.clan.current_season.lower() not in block["season"]
                     ):
@@ -157,7 +157,6 @@ class Dialogue():
                     if not flirt_success:
                         continue
 
-
         return possible_dialogue_keys
 
     def get_cat_dict(self):
@@ -172,7 +171,6 @@ class Dialogue():
         Returns the key and the dict object.
         """
         possible_dialogue_keys = self.filter_dialogue(possible_dialogue, flirt)
-
     
         if not possible_dialogue:
             possible_dialogue = load_lang_resource("lifegen_talk/general.json")
@@ -181,7 +179,7 @@ class Dialogue():
         debug_dict = {}
         for key in possible_dialogue_keys.copy():
             if len(possible_dialogue_keys) > 2:
-                if key in game.clan.talks:
+                if key in game.clan.talks and key != self.debug:
                     possible_dialogue_keys.remove(key)
             if key not in debug_dict:
                 debug_dict[key] = 1
@@ -193,6 +191,7 @@ class Dialogue():
         # print("DIALOGUE WEIGHTS")
         # for key, value in debug_dict.items():
         #     print(f"{key}: {value}")
+
         debug_valid = False
         chosen_key = None
         chosen_cat_dict = {}
@@ -215,7 +214,7 @@ class Dialogue():
                     cat_dict=self.cat_dict
                 )
                 debug_valid = True
-            elif self.debug in possible_dialogue:
+            elif self.debug in possible_dialogue_keys:
                 print(f"Debug: Dialogue set to {self.debug}")
                 chosen_key = self.debug
 
@@ -319,10 +318,16 @@ class Dialogue():
                     return
                 if inventory_block["addition"] == "choice":
                     chosen_accessory = random.choice(inventory_block["accessory"])
-                    cat_to_object.pelt.inventory.append(chosen_accessory)
+                    if chosen_accessory in Pelt.lifegen_acc_categories:
+                        cat_to_object.pelt.inventory.append(random.choice(Pelt.lifegen_acc_categories[chosen_accessory]))
+                    else:
+                        cat_to_object.pelt.inventory.append(random.choice(chosen_accessory))
                 elif inventory_block["addition"] == "all":
                     for acc in inventory_block["accessory"]:
-                        cat_to_object.pelt.inventory.append(acc)
+                        if acc in Pelt.lifegen_acc_categories:
+                            cat_to_object.pelt.inventory.append(random.choice(Pelt.lifegen_acc_categories[acc]))
+                        else:
+                            cat_to_object.pelt.inventory.append(acc)
 
         if relationship_block:
             unpack_rel_block(Cat, relationship_block, self, dialogue_dict=cat_dict)

--- a/scripts/events_module/dialogue/dialogue.py
+++ b/scripts/events_module/dialogue/dialogue.py
@@ -108,11 +108,13 @@ class Dialogue():
         # possible_texts = load_lang_resource("lifegen_talk/TEST.json")
         return possible_texts
 
-    def filter_dialogue(self, possible_texts):
+    def filter_dialogue(self, possible_texts, flirt):
         """
         Filters possible dialogue for selection.
         Season, biome, camp, and frequency are addressed here. Cats are validated later.
         """
+
+        flirt_success = self.get_flirt_success()
 
         possible_dialogue_keys = []
         for key, block in possible_texts.items():
@@ -144,6 +146,16 @@ class Dialogue():
             else:
                 print("Warning: Dialogue", key, "has no frequency.")
                 possible_dialogue_keys.append(key)
+            
+            if flirt:
+                if "tags" in block:
+                    if "reject" in block["tags"] and flirt_success:
+                        continue
+                    elif "accept" in block["tags"] and not flirt_success:
+                        continue
+                else:
+                    if not flirt_success:
+                        continue
 
 
         return possible_dialogue_keys
@@ -154,12 +166,12 @@ class Dialogue():
         """
         return self.cat_dict
 
-    def choose_dialogue(self, possible_dialogue):
+    def choose_dialogue(self, possible_dialogue, flirt=False):
         """
         Makes a final selection.
         Returns the key and the dict object.
         """
-        possible_dialogue_keys = self.filter_dialogue(possible_dialogue)
+        possible_dialogue_keys = self.filter_dialogue(possible_dialogue, flirt)
 
     
         if not possible_dialogue:
@@ -274,6 +286,13 @@ class Dialogue():
 
     def _populate_cat_dict(self, key, possible_cats_dict):
         self.dialogue_cat_dict[key] = possible_cats_dict
+    
+    def get_flirt_success(self):
+        if self.you.ID not in self.cat.relationships:
+            return False
+        if self.cat.relationships[self.you.ID].romance < 20:
+            return False
+        return True
 
     # ---------------------------------------------------------------------- #
     #                            SCENE EFFECTS                               #

--- a/scripts/events_module/dialogue/reformat/new_dialogue.json
+++ b/scripts/events_module/dialogue/reformat/new_dialogue.json
@@ -1,1 +1,12538 @@
-{}
+{
+    "oldflirts_1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Er, sorry, y_c ... But I don't see you that way."
+        ]
+    },
+    "bestie_reject": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, you meant that in, like, a 'best friends' way ... right?"
+        ]
+    },
+    "bestie_reject1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ehh ... Good one, bestie! Heh ..."
+        ]
+    },
+    "oldflirts_2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "introspective"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh... I didn't know you... saw me that way."
+        ]
+    },
+    "oldflirts_3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh wow, that was funny!",
+            "You're such a good friend."
+        ]
+    },
+    "oldflirts_4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, honey ...",
+            "That was... pretty terrible.",
+            "Please, let me teach you how to flirt."
+        ]
+    },
+    "oldflirts_5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I... already like someone else?"
+        ]
+    },
+    "oldflirts_6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Huh? Oh, um... Thank you? *Snrk*"
+        ]
+    },
+    "oldflirts_7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That's... nice of you to say."
+        ]
+    },
+    "oldflirts_8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Haha! That's the funniest joke I've heard all season!"
+        ]
+    },
+    "oldflirts_9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...That's a joke, right?"
+        ]
+    },
+    "oldflirts_10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful",
+                    "unabashed",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You've got to be joking."
+        ]
+    },
+    "oldflirts_11": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Eh, hehehe ... Might wanna rethink that one a little y_c."
+        ]
+    },
+    "oldflirts_12": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Whatever."
+        ]
+    },
+    "oldflirts_13": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Is that the best you could do?"
+        ]
+    },
+    "oldflirts_14": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Stop that, it's not getting you anywhere."
+        ]
+    },
+    "oldflirts_15": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "What is it going to take in order for you to leave me alone?"
+        ]
+    },
+    "oldflirts_16": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Congratulations, y_c!",
+            "That might just be the worst attempt at flirting I've heard in moons!"
+        ]
+    },
+    "oldflirts_17": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Okay?"
+        ]
+    },
+    "oldflirts_18": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Ew."
+        ]
+    },
+    "oldflirts_19": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. No."
+        ]
+    },
+    "oldflirts_20": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not a chance in StarClan."
+        ]
+    },
+    "oldflirts_21": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "rank": [
+                    "medicine cat",
+                    "medicine cat apprentice"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I think StarClan gave me an omen warning me about this."
+        ]
+    },
+    "oldflirts_22": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "cool",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You are <i>so</i> not my type."
+        ]
+    },
+    "oldflirts_23": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... y_c, was that supposed to be an insult, or an attempt at flirting?",
+            "Sorry, I genuinely can't tell."
+        ]
+    },
+    "oldflirts_24": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... No. You're not even on my playing field."
+        ]
+    },
+    "oldflirts_25": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. I'm too good for you..."
+        ]
+    },
+    "oldflirts_26": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, but I just don't see how this factors into my 20-moon plan."
+        ]
+    },
+    "oldflirts_27": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... What are you trying to do?"
+        ]
+    },
+    "oldflirts_28": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I think I'd rather take my chances with a Dark Forest cat."
+        ]
+    },
+    "oldflirts_29": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hehe! That was so funny, y_c!",
+            "This is why you're one of my closest friends."
+        ]
+    },
+    "oldflirts_30": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Are you trying to start a fight?"
+        ]
+    },
+    "oldflirts_31": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um, was that sarcasm?"
+        ]
+    },
+    "oldflirts_32": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...No. I'm sorry but just... no."
+        ]
+    },
+    "oldflirts_33": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh- me? Sorry, you aren't exactly my type..."
+        ]
+    },
+    "oldflirts_34": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... no."
+        ]
+    },
+    "oldflirts_35": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_50",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't talk to me."
+        ]
+    },
+    "oldflirts_36": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Just...no."
+        ]
+    },
+    "oldflirts_37": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm, I'd rather... not."
+        ]
+    },
+    "oldflirts_38": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "strangers"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do I know you?"
+        ]
+    },
+    "oldflirts_39": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "strangers"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, what's your name again?"
+        ]
+    },
+    "oldflirts_40": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "warrior"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ahahahahahaha! That was too good!",
+            "Wait, wait, stay right there! r_c:0, get over here! Listen to what y_c just said!"
+        ]
+    },
+    "oldflirts_41": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, uh I'm sorry, but I think I have to go..."
+        ]
+    },
+    "oldflirts_42": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "...",
+            "...",
+            "Let's pretend that didn't happen."
+        ]
+    },
+    "oldflirts_43": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um, what made you think I'd ever say yes?"
+        ]
+    },
+    "oldflirts_44": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "*Snrk* Did a badger teach you how to flirt?"
+        ]
+    },
+    "oldflirts_45": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Stop."
+        ]
+    },
+    "oldflirts_46": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're... you're kidding, right?"
+        ]
+    },
+    "oldflirts_47": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're delusional if you think you're good enough for me."
+        ]
+    },
+    "oldflirts_48": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh! Um, I'm gonna go..."
+        ]
+    },
+    "oldflirts_49": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I... just remembered something I have to do. Bye."
+        ]
+    },
+    "oldflirts_50": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... What's that supposed to mean?"
+        ]
+    },
+    "oldflirts_51": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, but I just see us as friends."
+        ]
+    },
+    "oldflirts_52": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh dear. Let me teach you how to flirt."
+        ]
+    },
+    "oldflirts_53": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh... sorry, but that was... horrible."
+        ]
+    },
+    "oldflirts_54": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "introspective"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... You've got a little something on your face..."
+        ]
+    },
+    "oldflirts_55": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh... I'm not that shallow."
+        ]
+    },
+    "oldflirts_56": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Frankly, I'd rather eat all our Clan's dirt left in the dirtplace."
+        ]
+    },
+    "oldflirts_57": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hmph. Not interested."
+        ]
+    },
+    "oldflirts_58": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um ... oof, this is awkward.",
+            "Tell you what, y_c. I'll do us both a favor and pretend this never happened. M'kay?"
+        ]
+    },
+    "oldflirts_59": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Aww, isn't that cute?",
+            "*Snrk*"
+        ]
+    },
+    "oldflirts_60": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed",
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Okay, I'm gonna stop you right there. I can see what you're doing and I'll save you the embarrassment in two simple words:",
+            "Not interested."
+        ]
+    },
+    "oldflirts_61": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh ... hehe! How sweet of you.",
+            "I'll be sure to tell that one to my mate later. {PRONOUN/r_c:0/subject/CAP}'ll definitely love it.",
+            "Ahem, and just to repeat it one more time ... my mate. Who I am in a very committed relationship with."
+        ]
+    },
+    "oldflirts_62": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hehe. Thanks, cutie. But I just don't like you like that.",
+            "Hey, keep your chin up, though. Plenty of other cats in the Clan who might catch your interest."
+        ]
+    },
+    "oldflirts_63": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, dear ... Um, why don't you just stick to admiring me from afar?"
+        ]
+    },
+    "oldflirts_64": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful",
+                    "unabashed",
+                    "silly",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hahaha! That one got me laughing!",
+            "As if we'd actually get together ... could you imagine?",
+            "Wait, could you say it again? I want to try it out on my crush."
+        ]
+    },
+    "oldflirts_65": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... For your own sake, I better have misheard you."
+        ]
+    },
+    "oldflirts_66": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Aw, bestie! That's sweet, but no. My heart belongs to another."
+        ]
+    },
+    "oldflirts_67": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... You don't wanna be with a cat like me. Trust me."
+        ]
+    },
+    "oldflirts_68": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Woah... Your breath stinks..."
+        ]
+    },
+    "oldflirts_69": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Eh ... Have you washed today..?"
+        ]
+    },
+    "oldflirts_70": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm sorry, y_c... We just ain't got that chemistry, you feel me?"
+        ]
+    },
+    "oldflirts_71": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ha! Very funny y_c!",
+            "Wait, you were serious?"
+        ]
+    },
+    "oldflirts_72": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c purrs and presses into your pelt.]",
+            "Say it again, just one more time?"
+        ]
+    },
+    "oldflirts_73": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh ... That one took me back to our courtship days. ~"
+        ]
+    },
+    "crush": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Ha, I remember when you first tried that line out on me.",
+            "For the next three days, it was all I could think about.",
+            "You really had me smitten!"
+        ]
+    },
+    "oldflirts_74": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed",
+                    "cool",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "If I act like I'm interested will it get you to stop?"
+        ]
+    },
+    "oldflirts_75": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "W-whatever..."
+        ]
+    },
+    "oldflirts_76": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "As much as I like you, we have got to work on your flirting ability, dear."
+        ]
+    },
+    "oldflirts_77": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ]
+            }
+        },
+        "intro": [
+            "Um- I like your eyes, too! They're really pretty!"
+        ]
+    },
+    "neurotic_flirt": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Ha ha. Very funny. No way a cat like you would ever flirt with me.",
+            "W-Wait, you mean ... It's not a joke? You really mean it?",
+            "[t_c suddenly flushes bright red.]",
+            "Uh, T-Thank you, y_c!"
+        ]
+    },
+    "neurotic_flirt1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Eep!",
+            "[t_c rushes away, blushing like crazy.]",
+            "[Seems like a good sign ...?]"
+        ]
+    },
+    "oldflirts_78": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Y- You really think so? Ah- thank you so much!"
+        ]
+    },
+    "oldflirts_79": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful",
+                    "unabashed",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Were you always this charming?",
+            "You certainly weren't when we were apprentices, that's for sure!",
+            "You bet I remember that time you fell face first into the lake. Who doesn't!"
+        ]
+    },
+    "oldflirts_80": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "sweet",
+                    "stable",
+                    "cool",
+                    "introspective",
+                    "upstanding"
+                ]
+            }
+        },
+        "intro": [
+            "Your pelt looks lovely in this lighting!"
+        ]
+    },
+    "oldflirts_81": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Aw, that's so nice of you!"
+        ]
+    },
+    "oldflirts_82": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ]
+            }
+        },
+        "intro": [
+            "T-Thank you... I guess I should say you've always been looking quite beautiful too!",
+            "Especially in the moonlight!"
+        ]
+    },
+    "oldflirts_83": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Oh, you're so cute sometimes! Do tell me more, hehe."
+        ]
+    },
+    "brooding_flirt_AJ": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No."
+        ]
+    },
+    "brooding_flirt_AJ1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "...",
+            "...*Blush*"
+        ]
+    },
+    "brooding_flirt_AJ2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "... You're very sweet. To say that."
+        ]
+    },
+    "brooding_flirt_AJ3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm. Why?"
+        ]
+    },
+    "brooding_flirt_AJ4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c buries {PRONOUN/t_c/poss} face in {PRONOUN/t_c/poss} paws shyly.]"
+        ]
+    },
+    "brooding_flirt_AJ5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c starts to purr.]"
+        ]
+    },
+    "brooding_flirt_AJ6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do you think I'm so shallow ...?"
+        ]
+    },
+    "brooding_flirt_AJ7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c narrows {PRONOUN/t_c/poss} eyes suspiciously.]",
+            "What's your angle?"
+        ]
+    },
+    "brooding_flirt_AJ8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding",
+                    "unlawful"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "mediator"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "strangers",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm ... Have you considered seeing r_c:0?",
+            "If you're seriously interested in me, you probably have some issues to work through."
+        ]
+    },
+    "brooding_flirt_AJ9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c allows the faintest hint of a smile to crack over {PRONOUN/t_c/poss} face.]",
+            "... Thank you."
+        ]
+    },
+    "cool_flirt": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Never took you for such a smooth talker, y_c. It's a little unnerving.",
+            "... But, I don't exactly hate it, either. ~"
+        ]
+    },
+    "cool_flirt_AJ": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "medicine cat",
+                    "medicine cat apprentice"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Echh. Someone get r_c:0. That was so sincere, I think it's causing an allergic reaction."
+        ]
+    },
+    "cool_flirt_AJ1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Cute. Can I go now?"
+        ]
+    },
+    "cool_flirt_AJ2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "queen"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, r_c:0? Remind me how you teach the kits to spell 'Out of your league'?"
+        ]
+    },
+    "cool_flirt_AJ3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Y'know, if I didn't know any better, I'd say you were flirting with me, y_c.~",
+            "Well, why'd you stop? I never said I didn't like it!"
+        ]
+    },
+    "cool_flirt_AJ4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "cool",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "That was. So lame. Ha.",
+            "[t_c looks away, blushing.]"
+        ]
+    },
+    "cool_flirt_AJ5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20"
+                ]
+            }
+        ],
+        "intro": [
+            "Huh. Y'know, that really wasn't half bad.",
+            "Who taught you that line? Was it me?"
+        ]
+    },
+    "cool_flirt_AJ6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_30"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, didn't I teach you that line?"
+        ]
+    },
+    "cool_flirt_AJ7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Testy. I like it."
+        ]
+    },
+    "cool_flirt_AJ8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Feeling's mutual, babe!~"
+        ]
+    },
+    "cool_flirt_AJ9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Heh. Always loved that line."
+        ]
+    },
+    "cool_flirt_AJ10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Uhm - What is this feeling?",
+            "I'm actually getting ... nervous?",
+            "Is this how regular cats feel all the time?"
+        ]
+    },
+    "oldflirts_84": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "neurotic",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Y-You deserve compliments much more than I do!"
+        ]
+    },
+    "oldflirts_85": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Awee, me? No way, you deserve all these compliments!"
+        ]
+    },
+    "oldflirts_86": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Heh... Thanks..."
+        ]
+    },
+    "oldflirts_87": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Aw, thank you! That's so sweet of you!"
+        ]
+    },
+    "oldflirts_88": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Wow... Your fur is really shiny today...",
+            "Was it always like that?"
+        ]
+    },
+    "oldflirts_89": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Is that so? Well, go on. Tell me more about how wonderful I am."
+        ]
+    },
+    "oldflirts_90": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "silly"
+                ]
+            }
+        },
+        "intro": [
+            "Oh goodness! You're so sweet!",
+            "Let me try...",
+            "Your fur looks so radiant in the sun today! Almost as radiant as your eyes.",
+            "Did I do good?"
+        ]
+    },
+    "oldflirts_91": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "hGK- Oh my goodness-",
+            "Sorry I wasn't expecting something as smooth as that!"
+        ]
+    },
+    "oldflirts_92": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "AWW!! That's so sweet of you!! You really think of me that way?"
+        ]
+    },
+    "oldflirts_93": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "unabashed"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Heh. I am quite attractive, aren't I? Do go on."
+        ]
+    },
+    "oldflirts_94": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Finally! Someone who noticed."
+        ]
+    },
+    "oldflirts_95": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding"
+                ]
+            }
+        },
+        "intro": [
+            "At least you have eyes."
+        ]
+    },
+    "oldflirts_96": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "unabashed",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Obviously."
+        ]
+    },
+    "oldflirts_97": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I always look lovely. Are you trying to imply that I don't?"
+        ]
+    },
+    "oldflirts_98": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "R-Really... me? ...",
+            "T... Thanks... it.. It really means a lot."
+        ]
+    },
+    "oldflirts_99": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... That was an awful attempt at flirting, but you are cute, so I'll let it slide."
+        ]
+    },
+    "oldflirts_100": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "intro": [
+            "... Thanks. I needed to hear that."
+        ]
+    },
+    "oldflirts_101": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Ah- I love you so much."
+        ]
+    },
+    "oldflirts_102": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Hahaha! At least you're funny."
+        ]
+    },
+    "upstanding_reject": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I just don't have time for something like this right now."
+        ]
+    },
+    "oldflirts_103": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "introspective",
+                    "upstanding"
+                ]
+            }
+        },
+        "intro": [
+            "You noticed!? Aw, thank you! I spent extra time grooming my pelt today!"
+        ]
+    },
+    "oldflirts_104": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "silly"
+                ]
+            }
+        },
+        "intro": [
+            "Hehe! You've got something on your face.. Here I'll get it!"
+        ]
+    },
+    "oldflirts_105": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding",
+                    "upstanding"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "..Thanks.. Your pelt looks... scruffy today?"
+        ]
+    },
+    "oldflirts_106": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unabashed",
+                    "sweet",
+                    "stable",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Aw! I love you, too!"
+        ]
+    },
+    "oldflirts_107": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "You're still just as good at flirting as when we first got together, you know?"
+        ]
+    },
+    "oldflirts_108": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "What's your secret? You always know what I need to hear before I do."
+        ]
+    },
+    "oldflirts_109": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Do you have some sort of secret StarClan cat in your dreams telling you how to woo me?",
+            "If so, tell them they're doing a great job."
+        ]
+    },
+    "oldflirts_110": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Awww!! Thank you!"
+        ]
+    },
+    "oldflirts_111": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Wait! Let me try one!",
+            "...",
+            ".....",
+            "Uhhhh...",
+            "You smell like the freshkill I ate this morning! It tasted really really good!"
+        ]
+    },
+    "oldflirts_112": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "sweet",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Aw! Aren't you adorable!"
+        ]
+    },
+    "oldflirts_113": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "If StarClan came for me tomorrow, I would be ready to go, knowing that I got to spend time with a cat as wonderful as you."
+        ]
+    },
+    "oldflirts_114": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates",
+                    "min_romance_20"
+                ]
+            }
+        ],
+        "intro": [
+            "You know, I never knew that I'd end up with a cat like you... But now that I'm here, I wouldn't have it any other way."
+        ]
+    },
+    "oldflirts_115": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "O-Oh! Wow, you're wonderful, you know that, right?"
+        ]
+    },
+    "oldflirts_116": {
+        "biome": [
+            "beach"
+        ],
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I must have sand in my ears... What was that again?"
+        ]
+    },
+    "oldflirts_117": {
+        "biome": [
+            "forest"
+        ],
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Mmm! You smell wonderful, like the forest just after rain!"
+        ]
+    },
+    "oldflirts_118": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "I... must agree that was actually neat. Look, I'm surprised."
+        ]
+    },
+    "oldflirts_119": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "introspective",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Uh- you smell good too! Like- catmint and lavender!"
+        ]
+    },
+    "oldflirts_120": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "introspective"
+                ]
+            }
+        },
+        "intro": [
+            "You know, your eyes look just like pools of water when they flash like that.",
+            "Has anyone ever told you that?"
+        ]
+    },
+    "oldflirts_121": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "What- uh, thanks! That's really nice of you."
+        ]
+    },
+    "oldflirts_122": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "Okay then. Thanks, I guess."
+        ]
+    },
+    "oldflirts_123": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "introspective"
+                ]
+            }
+        },
+        "intro": [
+            "Really? Well, your eyes are like moonlight!",
+            "And, uhm.. I'm not usually this nervous.. You flatter me."
+        ]
+    },
+    "oldflirts_124": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "silly"
+                ]
+            }
+        },
+        "intro": [
+            "You're beautiful like a butterfly, and you sparkle in the moonlight. Was that good, or what?"
+        ]
+    },
+    "oldflirts_125": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Thanks! That's the 15th time someone said I was beautiful today! I'm trying to get to 20!"
+        ]
+    },
+    "oldflirts_126": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "introspective",
+                    "neurotic"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "...",
+            "Dear StarClan, I- uhm..",
+            "I'm really not used to this..",
+            "Thank you. You're pretty, too."
+        ]
+    },
+    "oldflirts_127": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Your compliments are like a ray of sunshine in my bleak world."
+        ]
+    },
+    "oldflirts_128": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "silly"
+                ]
+            }
+        },
+        "intro": [
+            "Is it my turn now, hehe?",
+            "You're beautiful like moonlight, and, and, and...",
+            "Your fur is as soft as moss!",
+            "This is fun!"
+        ]
+    },
+    "oldflirts_129": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ],
+                "rank": [
+                    "deputy",
+                    "leader"
+                ]
+            }
+        },
+        "intro": [
+            "You're distracting me...",
+            "I need to focus on my duties, but you're too attractive."
+        ]
+    },
+    "oldflirts_130": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "silly",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Arrggh, stop making me feel weird! It feels like there's butterflies in my belly whenever I'm with you as is!"
+        ]
+    },
+    "oldflirts_131": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates",
+                    "max_dislike_25"
+                ]
+            }
+        ],
+        "intro": [
+            "I knew it. I've got the best mate EVER!"
+        ]
+    },
+    "oldflirts_132": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Thanks, honey. That was really cute even though it was kind of lame..."
+        ]
+    },
+    "oldflirts_133": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't worry! You'll get better one day."
+        ]
+    },
+    "oldflirts_134": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Thank you! I really appreciate it...",
+            "...Y'know, sometimes I doubt if I even deserve to be your mate.",
+            "But I just keep telling myself that you'd tell me if you didn't want to be mates.",
+            "And what you just said made me feel much better!"
+        ]
+    },
+    "oldflirts_135": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You really suck at that, you know? Hah."
+        ]
+    },
+    "oldflirts_136": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "... Oh, stop it. ~"
+        ]
+    },
+    "oldflirts_137": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "About that, I'm sorry for being so..",
+            "...Cold? -- Around you. I've been trying to get better with that sort of thing.",
+            "I guess I just get nervous."
+        ]
+    },
+    "heartbroken_1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "It's kind of you to say that, but my heart is elsewhere."
+        ]
+    },
+    "heartbroken_2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "I appreciate the gesture, but I'm not ready for this."
+        ]
+    },
+    "heartbroken_3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "heartbroken_4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "I need some time to heal from this heartbreak. Please understand."
+        ]
+    },
+    "heartbroken_5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "heartbroken_6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "It's not about you, it's about where my heart is right now."
+        ]
+    },
+    "heartbroken_7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "heartbroken_8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "heartbroken_9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "heartbroken_10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That's cool, but I've got other things on my mind."
+        ]
+    },
+    "heartbroken_11": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Life's strange, isn't it? I'm still trying to recover from my last relationship, and yet here you are."
+        ]
+    },
+    "heartbroken_12": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "cool",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Kind words, but I'm walking a solitary path for now."
+        ]
+    },
+    "heartbroken_13": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "heartbroken_14": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Trust is earned. Let's keep things as they are."
+        ]
+    },
+    "heartbroken_15": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "silly",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "Tempting, but I'm playing hard to get right now."
+        ]
+    },
+    "heartbroken_16": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "neurotic"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ]
+            }
+        },
+        "intro": [
+            "I'm... Taking things slow right now, but thank you."
+        ]
+    },
+    "flirt_sh_J25": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. Why would you say that to anycat, given your situation?",
+            "Murderers don't get love, y_c. Stop trying."
+        ]
+    },
+    "flirt_sh_J26": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Please don't say that to me right now."
+        ]
+    },
+    "flirt_sh_J27": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c just blinks at you, trying not to react.]"
+        ]
+    },
+    "flirt_sh_J28": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh, darling. Not now."
+        ]
+    },
+    "flirt_sh_J29": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c playfully taps you with {PRONOUN/t_c/poss} tail before pulling it away before anycat can see.]"
+        ]
+    },
+    "flirt_sh_J30": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "You're very cruel, y_c."
+        ]
+    },
+    "flirt_sh_J31": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "No, no, don't do that. Not now."
+        ]
+    },
+    "flirt_sh_J32": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates",
+                    "min_dislike_25",
+                    "min_romance_10"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Maybe I could have liked you if you weren't so evil."
+        ]
+    },
+    "flirt_sh_J33": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Oh, um... Thank you..."
+        ]
+    },
+    "flirt_sh_J34": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J35": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "y_c...?"
+        ]
+    },
+    "flirt_sh_J36": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J37": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J38": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh... Not now..."
+        ]
+    },
+    "flirt_sh_J39": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J40": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirting_shunned_CM1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "...... What?",
+            "y_c, oh, y_c. You know what I've done. You can't - we can't... oh no..",
+            "[t_c curls up on the ground, burying {PRONOUN/t_c/poss} face into {PRONOUN/t_c/poss} pelt as {PRONOUN/t_c/poss} muzzle turns red.]"
+        ]
+    },
+    "flirting_shunned_CM2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c frowns at you, {PRONOUN/t_c/poss} claws pressing out.]",
+            "You're not supposed to be talking to me, nevermind saying stupid things like that."
+        ]
+    },
+    "flirting_shunned_CM3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "leader"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No.",
+            "Now get lost before I tell r_c:0 all about what you just said to me.",
+            "I'm sure {PRONOUN/r_c:0/poss} face would be hilarious."
+        ]
+    },
+    "flirting_shunned_Ren1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "strangers"
+                ]
+            }
+        ],
+        "recent_murder": {
+            "victim": "r_c:0"
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[You approached t_c, quietly starting to flirt with {PRONOUN/t_c/object}.]",
+            "y_c. I murdered r_c:0. Why are you talking to me, let alone like this?",
+            "[You tell t_c that you never liked r_c:0 anyway, and maybe you like a little danger too.]"
+        ]
+    },
+    "flirting_shunned_Ren2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates",
+                    "min_dislike_10"
+                ]
+            }
+        ],
+        "recent_murder": {
+            "victim": "r_c:0"
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[You decide to start flirting with t_c in an attempt to see where it leads. {PRONOUN/t_c/subject/CAP} {VERB/t_c/do/does} not seem amused.]",
+            "y_c. I murdered r_c:0. I'm not afraid to go after you too if you keep at it.",
+            "[You try one more time, but t_c lashes out at you, not afraid to get more blood on {PRONOUN/t_c/poss} claws. It seems {PRONOUN/t_c/subject} {VERB/t_c/aren't/isn't} too fond of you.]"
+        ]
+    },
+    "flirting_shunned_SQ3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c backs away, {PRONOUN/t_c/poss} fur bristling.]",
+            "You aren't allowed to <i>talk</i> to me, let alone say something like that.",
+            "I might not be a murderer, but I still know how to use these claws.",
+            "Remember that next time you even <i>think</i> about opening your mouth."
+        ]
+    },
+    "flirt_sh_J41": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J42": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J43": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Hehe, I don't think that now is really the time..."
+        ]
+    },
+    "flirt_sh_J44": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time, y_c."
+        ]
+    },
+    "flirt_sh_J45": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... no."
+        ]
+    },
+    "flirt_sh_J46": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Maybe later, y_c."
+        ]
+    },
+    "flirting_shunned_SQ4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {},
+            "r_c:0": {
+                "rank": [
+                    "warrior"
+                ]
+            },
+            "r_c:1": {
+                "rank": [
+                    "leader"
+                ]
+            }
+        },
+        "intro": [
+            "[You call softly to t_c as {PRONOUN/t_c/subject} {VERB/t_c/pass/passes}, and {PRONOUN/t_c/subject} {VERB/t_c/stop/stops} in {PRONOUN/t_c/poss} tracks.]",
+            "I... y_c?",
+            "[Across the camp, r_c:1 pulls away from a discussion with r_c:0 and strides towards you, {PRONOUN/r_c:1/poss} eyes narrowed.]",
+            "[t_c hastily backs away as {PRONOUN/t_c/subject} also {VERB/t_c/notice/notices} r_c:1, though you see {PRONOUN/t_c/object} trying to hide {PRONOUN/t_c/poss} smile.]"
+        ]
+    },
+    "flirting_shunned_CM4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "... That gives me an idea, y_c.",
+            "c_n will never see us the same. We'll always be the dirt on their paws because we have blood on our own.",
+            "We should leave, y_c, make something for us - maybe an entire Clan. But I won't leave until you're ready to come with me.",
+            "I couldn't do it alone."
+        ]
+    },
+    "flirting_shunned_SQ1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_10"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares as you for a second, {PRONOUN/t_c/poss} tail lashing.]",
+            "What is wrong with you? Do you think this is some kind of opportunity? Just because the Clan hates us doesn't mean I have to... <i>like</i> you.",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/turn/turns} away, hissing over {PRONOUN/t_c/poss} shoulder.]",
+            "I have other things to worry about, y_c. You should probably get your priorities straight, too."
+        ]
+    },
+    "flirting_shunned_SQ2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "[Long after sundown, you and t_c are curled up in your makeshift nests at the edge of camp, but from {PRONOUN/t_c/poss} constant shifting, it's clear {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} having trouble sleeping.]",
+            "[You lean over and rest your head on t_c, whispering to {PRONOUN/t_c/object}. For a moment, {PRONOUN/t_c/subject} {VERB/t_c/seem/seems} frozen, but then {PRONOUN/t_c/subject} {VERB/t_c/press/presses} closer.]",
+            "You... mean that? Even now?",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/curl/curls} {PRONOUN/t_c/poss} tail around you, and you do the same. You stay like that for a while, listening to t_c's breathing and sounds from the camp where neither of you are welcome.]"
+        ]
+    },
+    "grieving_flirt_CM1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "min_like_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c barely looks up at you, choking out a sob as {PRONOUN/t_c/subject} {VERB/t_c/tremble/trembles}.]",
+            "y_c, y_c I'm sorry. I- <i>hic</i> I can't...",
+            "I can't love anyone like I did r_c:0.",
+            "It... if I lost you... it would destroy me if I did."
+        ]
+    },
+    "grieving_flirt_reuse1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "grieving_flirt_reuse2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I need some time to heal. Please understand."
+        ]
+    },
+    "grieving_flirt_reuse3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "grieving_flirt_reuse4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "grieving_flirt_reuse7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "grieving_flirt_Guy1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "min_romance_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
+            "How <b>dare</b> you y_c. How dare you think you can replace r_c:0!"
+        ]
+    },
+    "grieving_flirt_reuse11": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "grieving_flirt_reuse22": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "sweet",
+                    "stable",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I need some time to heal. Please understand."
+        ]
+    },
+    "grieving_flirt_reuse31": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "stable",
+                    "introspective",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "grieving_flirt_reuse42": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse51": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "unlawful"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse62": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "cool",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "grieving_flirt_reuse71": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "assertive",
+                    "brooding",
+                    "upstanding"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "grieving_flirt_Guy21": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "min_romance_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
+            "How <b>dare</b> you y_c. How dare you think you can replace r_c:0!"
+        ]
+    },
+    "grieving_flirt_reuse432": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse5121": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse41": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse511": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grievingyou_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "Wh-what?! y_c?!",
+            "I've finally lost my mind.",
+            "But, um... Thank you, ghost."
+        ]
+    },
+    "grievingyou_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I must be going insane. y_c is dead... {PRONOUN/y_c/subject} would never say that..."
+        ]
+    },
+    "grievingthem_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "intro": [
+            "I love and missed you too, y_c."
+        ]
+    },
+    "grievingthem_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're not thinking clearly right now..."
+        ]
+    },
+    "bothgrieving_flirt_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving",
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Absolutely not, y_c. Neither of us are in any state for this. Especially you."
+        ]
+    },
+    "bothgrieving_flirt_J10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "Come back later, y_c. Thank you, but I can't do this right now."
+        ]
+    },
+    "flirt_success_H9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "forgiven"
+                ]
+            }
+        },
+        "intro": [
+            "After all this time... you'll still speak to me so sweetly? Even after everything I've done?",
+            "You're a wonderful cat, y_c. I cannot thank you enough for your forgiveness."
+        ]
+    },
+    "flirt_reject_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do you have a death wish, or is this just to humiliate me?"
+        ]
+    },
+    "flirt_reject_H7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Get lost, I'm serious.",
+            "[t_c hisses in your direction, {PRONOUN/t_c/poss} tail lashing and claws extending.]"
+        ]
+    },
+    "flirt_reject_H8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're going to get in trouble, you know that."
+        ]
+    },
+    "flirt_reject_H9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm a murderer and you're still trying to get with me?",
+            "You have some dedication.",
+            "Not-- No, that's not a compliment!"
+        ]
+    },
+    "flirt_reject_H15": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You know, I would be flattered if there was some freshkill sent my way.",
+            "... No? Then you're not worth my time."
+        ]
+    },
+    "flirt_success_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Hmm... you amuse me, I'll give you that."
+        ]
+    },
+    "flirt_success_H7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "I'll admit, you have bravery saying those things under these circumstances.",
+            "I can't help but feel a bit flattered."
+        ]
+    },
+    "flirt_success_H8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c looks away, flustered.]",
+            "[Mission accomplished.]"
+        ]
+    },
+    "flirt_reject_H16": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "heartbroken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I cannot deal with this. Not while my life crumbles so quickly.",
+            "... Is this my karma?"
+        ]
+    },
+    "flirting_shunned_SQ5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you.]",
+            "I'm not even allowed to talk with r_c:0.",
+            "What makes you think I'd want to talk with you?"
+        ]
+    },
+    "flirt_reject_H17": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You must be a fool to believe I would take kindly to that.",
+            "Scram."
+        ]
+    },
+    "flirt_reject_H18": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'd consider this an insult."
+        ]
+    },
+    "flirt_reject_H10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "r_c:0 just died and you're trying to flirt with me?",
+            "... You need to get your priorities in order, y_c. Seriously."
+        ]
+    },
+    "flirt_reject_H13": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
+            "[Your flirting is not welcome, it seems.]"
+        ]
+    },
+    "flirt_Guy1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "unlawful",
+                    "brooding",
+                    "introspective"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c rolls {PRONOUN/t_c/poss} eyes and scoffs.]",
+            "Words said so often that they lack any meaning."
+        ]
+    },
+    "flirting_neurotic_SQ1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shrinks back. {PRONOUN/t_c/subject/CAP} {VERB/t_c/narrow/narrows} {PRONOUN/t_c/poss} eyes at {PRONOUN/t_c/poss} paws.]",
+            "Are you making fun of me? That's not nice, y_c."
+        ]
+    },
+    "flirting_neurotic_SQ2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ]
+            }
+        },
+        "intro": [
+            "...me?",
+            "[t_c's fur fluffs. {PRONOUN/t_c/poss/CAP} eyes dart from side to side, never quite meeting yours, as if {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} looking for another cat you might have been addressing.]",
+            "T-thank you?"
+        ]
+    },
+    "flirt_success_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "Heh, you... you mean that?",
+            "Wow..."
+        ]
+    },
+    "flirt_success_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c's ears go red and {PRONOUN/t_c/poss} eyes light up in awe.]",
+            "[You seem to have broken {PRONOUN/t_c/object} slightly with your awkward flirting.]"
+        ]
+    },
+    "flirt_success_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50"
+                ]
+            }
+        ],
+        "intro": [
+            "I thought we were just friends.",
+            "Heh, just kidding. I think you're really cute too."
+        ]
+    },
+    "flirt_success_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_30"
+                ]
+            }
+        ],
+        "intro": [
+            "You're joking with me.",
+            "N-no? You're not?",
+            "Am I dreaming or is this the luckiest day of my life?"
+        ]
+    },
+    "flirt_reject_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, wrap it up."
+        ]
+    },
+    "flirt_reject_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No, thanks."
+        ]
+    },
+    "flirt_reject_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... And what am I supposed to do with this information, exactly?"
+        ]
+    },
+    "flirt_reject_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Right, that made no sense.",
+            "You should work on your flirting a little more before you try again."
+        ]
+    },
+    "flirt_reject_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ],
+                "rank": [
+                    "leader",
+                    "deputy"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "warrior"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, sorry I think I just heard r_c:0 calling for me.",
+            "Time to do my duties! Haha... ha...",
+            "[t_c skitters off in a hurry. Was your flirting really that bad?]"
+        ]
+    },
+    "flirt_reject_H11": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hm? What?",
+            "Sorry, I couldn't hear you."
+        ]
+    },
+    "flirt_reject_H12": {
+        "season": [
+            "leaf-bare"
+        ],
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_15"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "What are you doing outside? It's so cold!",
+            "[t_c coaxes you back to somewhere warm. Alas, your attempt at flirting either went over {PRONOUN/t_c/poss} head... or was ignored.]",
+            "[You can't decide which one is worse.]"
+        ]
+    },
+    "flirt_reject_H14": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "blind:any:false",
+                    "heartbroken"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
+            "[Your flirting is not welcome, it seems.]"
+        ]
+    },
+    "flirt_reject_H19": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You have some nerve..."
+        ]
+    },
+    "blind_to_grieving_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't understand how you can flirt with me right now!",
+            "[t_c bursts into tears and buries {PRONOUN/t_c/poss} head underneath {PRONOUN/t_c/poss} paws.]"
+        ]
+    },
+    "deafflirt_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[While laying next to t_c in camp, you reach your paw towards {PRONOUN/t_c/inposs}.]",
+            "[{PRONOUN/t_c/poss/CAP} blush is so strong that you can feel it!]"
+        ]
+    },
+    "deafflirt_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[While laying next to t_c in camp, you reach your paw towards {PRONOUN/t_c/inposs}.]",
+            "[{PRONOUN/t_c/subject/CAP} quickly {VERB/t_c/flinch/flinches} and {VERB/t_c/shuffle/shuffles} away from you.]"
+        ]
+    },
+    "hasmate_success_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Don't tell r_c:0, but your flirting is a lot better than {PRONOUN/r_c:0/inposs}."
+        ]
+    },
+    "hasmate_success_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_20",
+                    "min_romance_20"
+                ]
+            }
+        ],
+        "intro": [
+            "You have a lot of nerve.",
+            "[Despite t_c's words, {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} to hide a smile.]"
+        ]
+    },
+    "hasmate_success_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c turns away, flustered by your flirting.]",
+            "[Just over {PRONOUN/t_c/poss} shoulder, you see r_c:0 watching from the distance, {PRONOUN/r_c:0/poss} tail lashing.]",
+            "[... Whoops.]"
+        ]
+    },
+    "hasmate_success_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh, do you mean that?",
+            "[r_c:0 calls for t_c in the distance. t_c almost jumps out of {PRONOUN/t_c/poss} fur in guilty surprise.]",
+            "Sorry, gotta go! I'll talk to you later!"
+        ]
+    },
+    "hasmate_success_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20"
+                ]
+            }
+        ],
+        "intro": [
+            "Does everycat want a piece of me, or what?",
+            "[t_c's chest puffs out, smug from all the attention.]"
+        ]
+    },
+    "hasmate_success_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh, r_c:0 beat you to it! Maybe next moon *wink*."
+        ]
+    },
+    "flirt_reject_H20": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {},
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "not_mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, y_c! Thank you! Do you know who else has gorgeous eyes?",
+            "r_c:0!~",
+            "[t_c sighs blissfully.]"
+        ]
+    },
+    "flirt_reject_H21": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "not_mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, I wish r_c:0 spoke to me like that!"
+        ]
+    },
+    "flirt_reject_H22": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "not_mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're really nice, y_c, but...",
+            "I can't get over r_c:0. I hope you understand!"
+        ]
+    },
+    "flirt_reject_H23": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {},
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "not_mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, y_c but... I have my eyes set out for r_c:0."
+        ]
+    },
+    "flirt_reject_H24": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "rank": [
+                    "medicine cat"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I would rather chew on ragwort than flirt with you."
+        ]
+    },
+    "flirt_reject_H25": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "rank": [
+                    "queen",
+                    "queen's apprentice"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm really busy with the kits right now, sorry! I'll talk to you later?"
+        ]
+    },
+    "flirt_reject_H26": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "rank": [
+                    "mediator"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... This is a weird way to ask for mediation."
+        ]
+    },
+    "flirt_reject_H27": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "min_max_faith": [
+                    0,
+                    9
+                ],
+                "rank": [
+                    "warrior"
+                ]
+            },
+            "r_c:0": {
+                "rank": [
+                    "deputy"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_50"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "StarClan, do I need to ask r_c:0 to set me out on more patrols so you'll stop flirting with me?"
+        ]
+    },
+    "hasmate_reject_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That was a nice attempt, but I am very happy with r_c:0."
+        ]
+    },
+    "hasmate_reject_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c laughs loudly at your flirting.]",
+            "Haha, good one, y_c! Oh, I can't wait to pass your joke to r_c:0!"
+        ]
+    },
+    "hasmate_reject_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Are you joking? You must be joking.",
+            "... you know I'm happily in a relationship with r_c:0... right?"
+        ]
+    },
+    "hasmate_reject_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_30",
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Back off before I call r_c:0 over."
+        ]
+    },
+    "hasmate_reject_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_30",
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you, unamused with your flirting.]",
+            "Stop that! Don't you know I'm with r_c:0?"
+        ]
+    },
+    "hasmate_reject_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, you're definitely not my type of cat."
+        ]
+    },
+    "hasmate_reject_H7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "What?",
+            "Oh. Sorry, you're nothing like the <i>love of my life</i>.",
+            "Do you get the hint, or..."
+        ]
+    },
+    "hasmate_reject_H8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Look, y_c, do you not see how happy I am with r_c:0?",
+            "You can't separate me from {PRONOUN/r_c:0/object}, but good luck trying."
+        ]
+    },
+    "hasmate_reject_H9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh uh, I just remembered that I need to do something!",
+            "With r_c:0, yup!",
+            "[t_c skitters off in a hurry.]"
+        ]
+    },
+    "hasmate_reject_H10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "rank": [
+                    "deputy"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates",
+                    "min_dislike_10"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c narrows {PRONOUN/t_c/poss} eyes at you, thoughtful.]",
+            "y_c, you are very brave, I'll give you that.",
+            "Oh, you know what? Since you're so brave, how about I place you on more border patrols?"
+        ]
+    },
+    "frommate_grieving_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm sorry, y_c, I'm... not in the mood right now."
+        ]
+    },
+    "frommate_grieving_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {},
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Haha...",
+            "You always know what to say to cheer me up.",
+            "[t_c smiles, but you can still see the deep sadness in {PRONOUN/t_c/poss} eyes.]"
+        ]
+    },
+    "frommate_grieving_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c smiles at you, but it's clear {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} not in the mood for flirting.]"
+        ]
+    },
+    "grieving_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c curls in a ball, ignoring your attempts to flirt.]"
+        ]
+    },
+    "frommate_reject_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "y_c, I'm not in the mood."
+        ]
+    },
+    "frommate_reject_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "y_c... is it just me or did your flirting become worse over the moons we've been together?",
+            "Oh... Yes, I am totally joking! Haha... ha..."
+        ]
+    },
+    "frommate_reject_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You must not mean that."
+        ]
+    },
+    "frommate_reject_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Awh! I can tell you've been... practicing that one!",
+            "Oh. You didn't? Uhem.",
+            "Ah -- Of course, I knew that! You're very... good. At flirting."
+        ]
+    },
+    "frommate_reject_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm going to be honest.",
+            "That was the worst, y_c."
+        ]
+    },
+    "guiltyblind_flirt_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "rank": [
+                    "any"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false",
+                    "guilt"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c curls in a ball, ignoring your attempts to flirt.]"
+        ]
+    },
+    "guiltyblind_flirt_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "rank": [
+                    "any"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false",
+                    "guilt"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c gives you an awkward smile, flushed by your actions.]"
+        ]
+    },
+    "guiltyblind_flirt_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "rank": [
+                    "any"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "guilt"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ah... I'm not feeling well right now, y_c.",
+            "Maybe later?"
+        ]
+    },
+    "youdeaf_R81": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:true"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_10"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c sees the flower you have and {PRONOUN/t_c/poss} eyes light up. {PRONOUN/t_c/subject/CAP} {VERB/t_c/motion/motions} the sign for 'thank you' with {PRONOUN/t_c/poss} head high, ears fluttering, and {PRONOUN/t_c/poss} whiskers twitching.]"
+        ]
+    },
+    "youdeaf_R82": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:true"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[Flirting might be harder without words, but it's worth it.]",
+            "[At least, t_c seems to appreciate your efforts as you can feel the purr rumbling {PRONOUN/t_c/poss} chest!]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/walk/walks} away with {PRONOUN/t_c/poss} head held high after.]"
+        ]
+    },
+    "youdeaf_R83": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:true"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "silly",
+                    "neurotic"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/duck/ducks} {PRONOUN/t_c/poss} head shyly in response.]"
+        ]
+    },
+    "youdeaf_R84": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c frowns a little at your flirting attempt. {PRONOUN/t_c/subject/CAP} {VERB/t_c/turn/turns} away without a response.]"
+        ]
+    },
+    "youdeaf_R85": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem to know how to respond.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_01": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh... really? Huh, no one has ever said that to me before... Thank you- I'm sorry I don't really know what to say.",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/let/lets} out a chuckle, {PRONOUN/t_c/poss} whiskers twitching slightly as {PRONOUN/t_c/subject} {VERB/t_c/try/tries} to hide {PRONOUN/t_c/poss} growing smile.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_02": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false",
+                    "hearing"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "!!!",
+            "I think I hear my training calling me- foxdung! I meant my mentor! Because training is a task and you can't hear a task- that's so stupid! Hahaha! Yeah I hear my train- I mean my...",
+            "SEE YOU LATER!",
+            "[t_c darts away, {PRONOUN/t_c/poss} fur on end- you swear you can see the tips of {PRONOUN/t_c/poss} ears turn red.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_03": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "app/mentor"
+                ]
+            }
+        ],
+        "intro": [
+            "Did your mentor teach you to flirt like that? Maybe I should ask r_c:0 if {PRONOUN/r_c:0/subject} {VERB/r_c:0/have/has} any tips...Because that right there, that is a life skill."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_04": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Woah, is this how adults feel? When they have mates... I suddenly feel all light and hot all the sudden...",
+            "Quickly! Say something else! I need to know if this is normal!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_05": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Maybe being friends can go somewhere else... That doesn't sound too bad... What do you think?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_06": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Since when did you get so smooth? I thought we were friends, you keeping these super cool and overpowered flirting skills a secret from me?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_07": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "cluster": [
+                    "introspective",
+                    "neurotic"
+                ],
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "cool",
+                    "upstanding"
+                ],
+                "age": [
+                    "adolescent"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50",
+                    "min_romance_10",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "If you think I'm pretty, take a look at yourself.",
+            "GAH!",
+            "I mean that as a friend in a platonic way because if that was meant to be romantic then... You know what? Forget it, you y_c, are beautiful like a ray of sunshine and it bothers me that you don't see it.",
+            "...",
+            "You're very pretty."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_08": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_30",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "You're too kind, y_c... I'm so happy to be your friend and maybe... maybe one day, something... more..."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_09": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_40",
+                    "non-mates"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "app/mentor"
+                ]
+            }
+        ],
+        "intro": [
+            "HA! Good one!",
+            "Wait- are you serious? You are?",
+            "[t_c's ears raise up higher, a grin on {PRONOUN/r_c:0/poss} face as {PRONOUN/r_c:0/poss} eyes light up.]",
+            "Thank you, y_c!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "If you distract my training with your sweet words then I'm going to steal your share of the freshkill later. I hate the fact that I love you.",
+            "...",
+            "AS A FRIEND!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_11": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "cool",
+                    "brooding"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_30",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Please don't ever change, y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_12": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "unabashed",
+                    "stable"
+                ],
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50",
+                    "min_romance_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Is this the origins of our love story? Please say yes!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_01": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "You're too nice, y_c... Wow, yeah... Way too nice- I don't deserve such wonderful words. You on the other paw, you deserve all the praise."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_02": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Thank you. That means a lot, your words will help me get through today. Thank you y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_03": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "...",
+            "You... You shouldn't say such things...",
+            "I cannot afford to get distracted... Not by a cat such as yourself...",
+            "...",
+            "You're- I need to go.",
+            "[Before you can object, t_c stumbles away, {PRONOUN/t_c/poss} eyes lowered to the ground. You can't help but feel your words are going to stick with {PRONOUN/t_c/object} for a while.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_04": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "A cat like me doesn't deserve this praise.",
+            "You're the beautiful one here, strong, intelligent, kind and capable... Beautiful..."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_05": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "When did you become so... articulate?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_06": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Is that something normal for a friend to say?",
+            "Because I feel that maybe you said that with- flirtatious intentions...",
+            "But, we're friends though, aren't we?",
+            "Unless... You want to be more?",
+            "[{PRONOUN/t_c/poss/CAP} whiskers twitch slightly as {PRONOUN/t_c/subject} smile, {PRONOUN/t_c/poss} eyes full of unexplainable emotions... Maybe {PRONOUN/t_c/subject} also want to be more than friends? You both can't help but wonder what the future holds.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_07": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "I love you too, y_c! I always have and I always will.",
+            "You look a little flushed there, don't worry- I meant what I said. I'll leave you to ponder that thought!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_08": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh- Stop it you! You're going to make me lose concentration!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_09": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_20",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Says the cat with the stars in {PRONOUN/y_c/poss} eyes and paws as gentle as the river banks. You're the beautiful one here, y_c. Not even Silverpelt could compare to the sight you behold."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_like_50",
+                    "non-mates"
+                ]
+            }
+        ],
+        "intro": [
+            "... Say that again, please. I need to hear it to make sure I heard it correctly.",
+            "Oh... it was what I heard, I'm glad we share the same sentiment."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_01": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Says the cat with the stars in {PRONOUN/y_c/poss} eyes and paws as gentle as the river banks. You're the beautiful one here, y_c. Not even Silverpelt could compare to the sight you behold."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_02": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Not a day goes past where I am not thankful to be welcomed by your embrace... You're perfect, mind, body and soul. I love you y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_03": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Still as sharp as before we got together, aren't you, love?",
+            "Well, please don't stop there, surely there's more you have to say~ If not, I could talk for a little while."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_04": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Please, never leave my side y_c. I love you dearly, your words are a blessing to be heard. I never want that to be taken away from me.",
+            "[You assure t_c that you'll never leave {PRONOUN/t_c/poss} side. {PRONOUN/t_c/subject/CAP} curls closer to you in your shared bed and begins to purr. You groom {PRONOUN/t_c/poss} fur and whisper soft words of affection- soft enough so only the both of you can hear.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_05": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable"
+                ],
+                "age": [
+                    "adult"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "GAH-",
+            "Love, I- pft!",
+            "[t_c explodes into a fit of giggles.]",
+            "You always know what to say."
+        ]
+    },
+    "neurotic_flirt_SQ3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "max_dislike_5"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c giggles, then looks embarrassed.]",
+            "S-sorry! I... um... That was really sweet...",
+            "[t_c smiles shyly, then scurries away.]"
+        ]
+    },
+    "neurotic_flirt_SQ4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "max_dislike_5"
+                ]
+            }
+        ],
+        "intro": [
+            "I... I think you look really nice, too!",
+            "[t_c says the words very quickly, then hightails it to the other side of camp.]"
+        ]
+    },
+    "neurotic_flirt_SQ5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "neurotic"
+                ],
+                "age": [
+                    "adolescent",
+                    "not_kitten"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "t_c"
+                ],
+                "relationship": [
+                    "app/mentor"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh! Um...",
+            "[t_c freezes, casting {PRONOUN/t_c/poss} gaze around camp.]",
+            "Ah... sorry, what did you say?",
+            "Oh, actually, r_c:0 needs to talk to me about an assessment... right now, it looks like! Sorry, I'll see you later!"
+        ]
+    },
+    "niche_situations_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "niche_situations_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken",
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "niche_situations_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "flirt_SAM1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[You trot up to t_c and rub heads with {PRONOUN/t_c/poss}, earning a small blush.]",
+            "[t_c is seen grinning like a fool afterwards, but {PRONOUN/t_c/subject} {VERB/t_c/try/tries} to hide it.]"
+        ]
+    },
+    "murder_flirt_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "recent_murder": {
+            "victim": {
+                "cat": "t_c"
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Umm....",
+            "I'm getting very mixed signals from you lately, y_c."
+        ]
+    },
+    "murder_flirt_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "recent_murder": {
+            "accomplice": {
+                "success": true
+            }
+        },
+        "intro": [
+            "Hehehe... I think we make a great team, too, y_c~!"
+        ]
+    },
+    "newshunned_flirt_J1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "brooding"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "max_like_10"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hm? Are you really bored enough to try hitting on me?",
+            "Yeesh. There's gotta be better things for you to do. Go try drawing in the dirt, or something. I'm not that desperate yet."
+        ]
+    },
+    "newshunned_flirt_J2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "strangers"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't find murderers very attractive, y_c. Sorry."
+        ]
+    },
+    "newshunned_flirt_J3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "cluster": [
+                    "stable",
+                    "silly"
+                ],
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "Oh, hush! Even now, you're finding a way to make me smile.",
+            "How do you do it?"
+        ]
+    },
+    "youshunned_flirt_rad1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You take 'heartstopper' both literally and figuratively, huh?"
+        ]
+    },
+    "accomplice_flirt_reject_rad1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "recent_murder": {
+            "accomplice": {
+                "success": true
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I agreed to be your partner in crime, not your partner in life."
+        ]
+    },
+    "flirt_accomplicereject_rad1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "not_kitten"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "not_kitten"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares at you in confusion.]",
+            "You have a <i>weird</i> way of trying to flatter me."
+        ]
+    },
+    "you_shunned_flirt_E1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_30"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c recoils with a hiss.]"
+        ]
+    },
+    "you_shunned_flirt_E2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "max_like_25",
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c blatantly ignores you, barely even twitching an ear as {PRONOUN/t_c/subject} {VERB/t_c/pad/pads} by.]",
+            "[It's like you're invisible.]"
+        ]
+    },
+    "they_shunned_flirt_E1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_romance_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "There's a time and a place, y_c. This isn't either of those."
+        ]
+    },
+    "flirt_app_reject_rad1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c looks away, but {PRONOUN/t_c/poss} face clearly reveals {PRONOUN/t_c/poss} discomfort.]",
+            "[... Not the reaction you'd hoped for.]"
+        ]
+    },
+    "flirt_app_reject_rad2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "[Judging by the lengthy pause, you suspect t_c feels extremely uncomfortable.]",
+            "[You don't blame {PRONOUN/t_c/object}. You feel uncomfortable now, too.]"
+        ]
+    },
+    "flirt_app_reject_rad3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c backs away, eyes averted.]"
+        ]
+    },
+    "flirt_app_reject_rad4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares at you blankly.]"
+        ]
+    },
+    "flirt_app_reject_rad5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c looks at you uncertainly, as though {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} hoping you aren't serious.]"
+        ]
+    },
+    "flirt_app_reject_rad6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ]
+            },
+            "r_c:0": {}
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "r_c:0"
+                ],
+                "relationship": [
+                    "min_romance_20",
+                    "not_mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's eyes are fixed on r_c:0 across camp.]",
+            "... Oh, sorry, y_c! What were you saying?"
+        ]
+    },
+    "flirt_app_reject_rad7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "skill": [
+                    "TUNNELER,1"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[As you and t_c are sharing tongues, you nervously shift to press yourself against {PRONOUN/t_c/subject} pelt.]",
+            "[t_c stiffens, then pulls away.]",
+            "[... You're tempted to go hide in the nearest tunnel for the next few moons until the embarrassment wears off.]"
+        ]
+    },
+    "flirt_app_reject_rad8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adolescent"
+                ],
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[After what feels like moons of working up the courage, you gingerly run your tail over t_c's shoulders.]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/jerk/jerks} away sharply, leaving your entire pelt burning with embarrassment.]"
+        ]
+    },
+    "flirt_jfstick_reject_rad1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ],
+                "rank": [
+                    "medicine cat"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c seems too fixated on a stick to even notice you.]"
+        ]
+    },
+    "deafgrievingflirt_SQ1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adult"
+                ],
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[You press against t_c. {PRONOUN/t_c/subject/CAP} {VERB/t_c/keep/keeps} {PRONOUN/t_c/poss} eyes closed, but press back against you.]",
+            "[You think you hear a small purr, but it quickly turns to sobs.]"
+        ]
+    },
+    "deafgrievingflirt_SQ2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "age": [
+                    "adult"
+                ]
+            },
+            "t_c": {
+                "age": [
+                    "adult"
+                ],
+                "condition": [
+                    "deaf:any:true",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c lifts {PRONOUN/t_c/poss} head to look at you. {PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} initially react to your signs, so you try again.]",
+            "[...Your mate just sighs and drops {PRONOUN/t_c/poss} head back on {PRONOUN/t_c/poss} paws, sniffling.]"
+        ]
+    },
+    "flirt_sam2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:true"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c presses {PRONOUN/t_c/poss} pelt into yours so that you can feel {PRONOUN/t_c/poss} purrs.]"
+        ]
+    },
+    "shunned_deaf_flirt_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c smiles slightly. Even though {PRONOUN/t_c/subject} {VERB/t_c/seem/seems} hesitant, t_c doesn't appear to hate your flirting.]"
+        ]
+    },
+    "shunned_deaf_flirt_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c turns {PRONOUN/t_c/poss} head away and lashes {PRONOUN/t_c/poss} tail.]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem impressed.]"
+        ]
+    },
+    "shunned_grieving_flirt_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_10",
+                    "non-mates"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Go away!"
+        ]
+    },
+    "shunned_grieving_flirt_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I do not want to speak with you right now, y_c.",
+            "Please, leave me to grieve."
+        ]
+    },
+    "shunned_grieving_flirt_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I do not want to speak with you right now, y_c.",
+            "Please, leave me to grieve."
+        ]
+    },
+    "shunned_grieving_flirt_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't you think you have caused me enough suffering? I do not need your awful flirting on top of it."
+        ]
+    },
+    "deaf_grieving_flirt_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false",
+                    "grief stricken"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "deaf_grieving_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "deaf_grieving_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "flirt_hate_sam1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ],
+                "min_max_faith": [
+                    0,
+                    9
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_40"
+                ]
+            }
+        ],
+        "intro": [
+            "What in StarClan?",
+            "I-I hate you! I don't like you like that!",
+            "[t_c scurries away, {PRONOUN/t_c/poss} pelt burning with embarrassment.]",
+            "[Maybe t_c doesn't hate you after all.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {}
+        },
+        "intro": [
+            "You're so pretty even when you cry."
+        ]
+    },
+    "mcgrievingonly_flirting_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "intro": [
+            "You're being really sweet, but take care of yourself, yeah?",
+            "How about we visit r_c:0 later?"
+        ]
+    },
+    "mcgrievingonly_flirting_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {}
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Has anycat ever told you to look ugly when you cry?"
+        ]
+    },
+    "mcgrievingonly_flirting_H6": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Are you using flirting as a coping mechanism?"
+        ]
+    },
+    "mcgrievingonly_flirting_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "non-mates",
+                    "min_like_20"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, uh, sorry, but I think you should be reflecting in your feelings before flirting with anycat. You know, think about yourself first."
+        ]
+    },
+    "mcgrievingonly_flirting_H5": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "I think that's the most heartfelt thing you've said in a while. Are you feeling feverish or something?",
+            "Hehe, just kidding."
+        ]
+    },
+    "mcgrievingonly_flirting_H7": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "min_dislike_25"
+                ]
+            },
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "intro": [
+            "Did r_c:0 going to StarClan make you finally realize you like me?"
+        ]
+    },
+    "mcgrievingonly_flirting_c": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "There's something beautiful about how much you miss them."
+        ]
+    },
+    "mcgrievingonly_flirting_c2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "intro": [
+            "The way you loved r_c:0...",
+            "It does make me wonder what it would feel to be loved like that too."
+        ]
+    },
+    "mcgrievingonly_flirting_c3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false"
+                ]
+            },
+            "r_c:0": {
+                "residence": [
+                    "any"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c:0"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "dead/grieving"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shuffles their paws, not meeting your eyes.]",
+            "[It doesn't feel entirely appropriate to accept your advances, not when you're missing r_c:0 so much.]"
+        ]
+    },
+    "bothgrieving_flirt_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "You're a nice distraction."
+        ]
+    },
+    "bothgrieving_flirt_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            }
+        },
+        "intro": [
+            "Determined to distract the both of us from our grievances, huh?",
+            "I won't complain."
+        ]
+    },
+    "bothgrieving_flirt_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now is not the time, y_c..."
+        ]
+    },
+    "bothgrieving_flirt_H4": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false",
+                    "blind:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c avoids your flirting by sitting with {PRONOUN/t_c/poss} back facing you.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H8": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false",
+                    "blind:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "blind:any:false",
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "mates"
+                ]
+            }
+        ],
+        "intro": [
+            "[t_c decides to cuddle with you instead of encouraging the flirting, hoping to make you feel better.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H9": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "intro": [
+            "[t_c smiles, taking your flirting in stride.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H10": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "deaf:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c smiles, but {PRONOUN/t_c/subject} {VERB/t_c/look/looks} a little awkward around the eyes.]"
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H1": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "condition": [
+                    "deaf:any:false"
+                ],
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken",
+                    "deaf:any:false",
+                    "blind:any:false"
+                ]
+            }
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c ignores you with a flick of {PRONOUN/t_c/poss} tail.]"
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H2": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken"
+                ],
+                "skill": [
+                    "STAR,1",
+                    "DARK,1",
+                    "GHOST,1"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're not real, you're not real, you're not real."
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H3": {
+        "frequency": 2,
+        "cats": {
+            "y_c": {
+                "standing": [
+                    "member",
+                    "shunned"
+                ]
+            },
+            "t_c": {
+                "condition": [
+                    "grief stricken"
+                ]
+            }
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "t_c"
+                ],
+                "cats_to": [
+                    "y_c"
+                ],
+                "relationship": [
+                    "grieving/dead"
+                ]
+            }
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Is my mind playing tricks on me?"
+        ]
+    }
+}

--- a/scripts/events_module/dialogue/reformat/old_dialogue.json
+++ b/scripts/events_module/dialogue/reformat/old_dialogue.json
@@ -1,1 +1,9365 @@
-{}
+{
+    "oldflirts_1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Er, sorry, y_c ... But I don't see you that way."
+        ]
+    },
+    "bestie_reject": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, you meant that in, like, a 'best friends' way ... right?"
+        ]
+    },
+    "bestie_reject1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ehh ... Good one, bestie! Heh ..."
+        ]
+    },
+    "oldflirts_2": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "introspective"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh... I didn't know you... saw me that way."
+        ]
+    },
+    "oldflirts_3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh wow, that was funny!",
+            "You're such a good friend."
+        ]
+    },
+    "oldflirts_4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, honey ...",
+            "That was... pretty terrible.",
+            "Please, let me teach you how to flirt."
+        ]
+    },
+    "oldflirts_5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I... already like someone else?"
+        ]
+    },
+    "oldflirts_6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Huh? Oh, um... Thank you? *Snrk*"
+        ]
+    },
+    "oldflirts_7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That's... nice of you to say."
+        ]
+    },
+    "oldflirts_8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Haha! That's the funniest joke I've heard all season!"
+        ]
+    },
+    "oldflirts_9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...That's a joke, right?"
+        ]
+    },
+    "oldflirts_10": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful",
+                "unabashed",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You've got to be joking."
+        ]
+    },
+    "oldflirts_11": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Eh, hehehe ... Might wanna rethink that one a little y_c."
+        ]
+    },
+    "oldflirts_12": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Whatever."
+        ]
+    },
+    "oldflirts_13": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Is that the best you could do?"
+        ]
+    },
+    "oldflirts_14": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Stop that, it's not getting you anywhere."
+        ]
+    },
+    "oldflirts_15": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "What is it going to take in order for you to leave me alone?"
+        ]
+    },
+    "oldflirts_16": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Congratulations, y_c!",
+            "That might just be the worst attempt at flirting I've heard in moons!"
+        ]
+    },
+    "oldflirts_17": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Okay?"
+        ]
+    },
+    "oldflirts_18": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Ew."
+        ]
+    },
+    "oldflirts_19": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. No."
+        ]
+    },
+    "oldflirts_20": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not a chance in StarClan."
+        ]
+    },
+    "oldflirts_21": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "status": [
+                "medicine cat",
+                "medicine cat apprentice"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I think StarClan gave me an omen warning me about this."
+        ]
+    },
+    "oldflirts_22": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "cool",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You are <i>so</i> not my type."
+        ]
+    },
+    "oldflirts_23": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... y_c, was that supposed to be an insult, or an attempt at flirting?",
+            "Sorry, I genuinely can't tell."
+        ]
+    },
+    "oldflirts_24": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... No. You're not even on my playing field."
+        ]
+    },
+    "oldflirts_25": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. I'm too good for you..."
+        ]
+    },
+    "oldflirts_26": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, but I just don't see how this factors into my 20-moon plan."
+        ]
+    },
+    "oldflirts_27": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... What are you trying to do?"
+        ]
+    },
+    "oldflirts_28": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I think I'd rather take my chances with a Dark Forest cat."
+        ]
+    },
+    "oldflirts_29": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hehe! That was so funny, y_c!",
+            "This is why you're one of my closest friends."
+        ]
+    },
+    "oldflirts_30": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Are you trying to start a fight?"
+        ]
+    },
+    "oldflirts_31": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um, was that sarcasm?"
+        ]
+    },
+    "oldflirts_32": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...No. I'm sorry but just... no."
+        ]
+    },
+    "oldflirts_33": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh- me? Sorry, you aren't exactly my type..."
+        ]
+    },
+    "oldflirts_34": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... no."
+        ]
+    },
+    "oldflirts_35": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_50",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't talk to me."
+        ]
+    },
+    "oldflirts_36": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Just...no."
+        ]
+    },
+    "oldflirts_37": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm, I'd rather... not."
+        ]
+    },
+    "oldflirts_38": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "neutral"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do I know you?"
+        ]
+    },
+    "oldflirts_39": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "neutral"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, what's your name again?"
+        ]
+    },
+    "oldflirts_40": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ahahahahahaha! That was too good!",
+            "Wait, wait, stay right there! r_w, get over here! Listen to what y_c just said!"
+        ]
+    },
+    "oldflirts_41": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, uh I'm sorry, but I think I have to go..."
+        ]
+    },
+    "oldflirts_42": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "...",
+            "...",
+            "Let's pretend that didn't happen."
+        ]
+    },
+    "oldflirts_43": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um, what made you think I'd ever say yes?"
+        ]
+    },
+    "oldflirts_44": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "*Snrk* Did a badger teach you how to flirt?"
+        ]
+    },
+    "oldflirts_45": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Stop."
+        ]
+    },
+    "oldflirts_46": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're... you're kidding, right?"
+        ]
+    },
+    "oldflirts_47": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're delusional if you think you're good enough for me."
+        ]
+    },
+    "oldflirts_48": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh! Um, I'm gonna go..."
+        ]
+    },
+    "oldflirts_49": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I... just remembered something I have to do. Bye."
+        ]
+    },
+    "oldflirts_50": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... What's that supposed to mean?"
+        ]
+    },
+    "oldflirts_51": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {},
+        "relationship": [
+            "min_platonic_50",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, but I just see us as friends."
+        ]
+    },
+    "oldflirts_52": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh dear. Let me teach you how to flirt."
+        ]
+    },
+    "oldflirts_53": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh... sorry, but that was... horrible."
+        ]
+    },
+    "oldflirts_54": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "introspective"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... You've got a little something on your face..."
+        ]
+    },
+    "oldflirts_55": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh... I'm not that shallow."
+        ]
+    },
+    "oldflirts_56": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Frankly, I'd rather eat all our Clan's dirt left in the dirtplace."
+        ]
+    },
+    "oldflirts_57": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hmph. Not interested."
+        ]
+    },
+    "oldflirts_58": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um ... oof, this is awkward.",
+            "Tell you what, y_c. I'll do us both a favor and pretend this never happened. M'kay?"
+        ]
+    },
+    "oldflirts_59": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Aww, isn't that cute?",
+            "*Snrk*"
+        ]
+    },
+    "oldflirts_60": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed",
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Okay, I'm gonna stop you right there. I can see what you're doing and I'll save you the embarrassment in two simple words:",
+            "Not interested."
+        ]
+    },
+    "oldflirts_61": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "relationship": [
+            "non-mates"
+        ],
+        "intro": [
+            "Uh ... hehe! How sweet of you.",
+            "I'll be sure to tell that one to my mate later. {PRONOUN/t_m/subject/CAP}'ll definitely love it.",
+            "Ahem, and just to repeat it one more time ... my mate. Who I am in a very committed relationship with."
+        ]
+    },
+    "oldflirts_62": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hehe. Thanks, cutie. But I just don't like you like that.",
+            "Hey, keep your chin up, though. Plenty of other cats in the Clan who might catch your interest."
+        ]
+    },
+    "oldflirts_63": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, dear ... Um, why don't you just stick to admiring me from afar?"
+        ]
+    },
+    "oldflirts_64": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful",
+                "unabashed",
+                "silly",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hahaha! That one got me laughing!",
+            "As if we'd actually get together ... could you imagine?",
+            "Wait, could you say it again? I want to try it out on my crush."
+        ]
+    },
+    "oldflirts_65": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... For your own sake, I better have misheard you."
+        ]
+    },
+    "oldflirts_66": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Aw, bestie! That's sweet, but no. My heart belongs to another."
+        ]
+    },
+    "oldflirts_67": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... You don't wanna be with a cat like me. Trust me."
+        ]
+    },
+    "oldflirts_68": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Woah... Your breath stinks..."
+        ]
+    },
+    "oldflirts_69": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Eh ... Have you washed today..?"
+        ]
+    },
+    "oldflirts_70": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm sorry, y_c... We just ain't got that chemistry, you feel me?"
+        ]
+    },
+    "oldflirts_71": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "sweet",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ha! Very funny y_c!",
+            "Wait, you were serious?"
+        ]
+    },
+    "oldflirts_72": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c purrs and presses into your pelt.]",
+            "Say it again, just one more time?"
+        ]
+    },
+    "oldflirts_73": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh ... That one took me back to our courtship days. ~"
+        ]
+    },
+    "crush": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Ha, I remember when you first tried that line out on me.",
+            "For the next three days, it was all I could think about.",
+            "You really had me smitten!"
+        ]
+    },
+    "oldflirts_74": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed",
+                "cool",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "If I act like I'm interested will it get you to stop?"
+        ]
+    },
+    "oldflirts_75": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "W-whatever..."
+        ]
+    },
+    "oldflirts_76": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "As much as I like you, we have got to work on your flirting ability, dear."
+        ]
+    },
+    "oldflirts_77": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Um- I like your eyes, too! They're really pretty!"
+        ]
+    },
+    "neurotic_flirt": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Ha ha. Very funny. No way a cat like you would ever flirt with me.",
+            "W-Wait, you mean ... It's not a joke? You really mean it?",
+            "[t_c suddenly flushes bright red.]",
+            "Uh, T-Thank you, y_c!"
+        ]
+    },
+    "neurotic_flirt1": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Eep!",
+            "[t_c rushes away, blushing like crazy.]",
+            "[Seems like a good sign ...?]"
+        ]
+    },
+    "oldflirts_78": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Y- You really think so? Ah- thank you so much!"
+        ]
+    },
+    "oldflirts_79": {
+        "y_c": {
+            "age": [
+                "adult"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful",
+                "unabashed",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Were you always this charming?",
+            "You certainly weren't when we were apprentices, that's for sure!",
+            "You bet I remember that time you fell face first into the lake. Who doesn't!"
+        ]
+    },
+    "oldflirts_80": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "sweet",
+                "stable",
+                "cool",
+                "introspective",
+                "upstanding"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Your pelt looks lovely in this lighting!"
+        ]
+    },
+    "oldflirts_81": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Aw, that's so nice of you!"
+        ]
+    },
+    "oldflirts_82": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "T-Thank you... I guess I should say you've always been looking quite beautiful too!",
+            "Especially in the moonlight!"
+        ]
+    },
+    "oldflirts_83": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, you're so cute sometimes! Do tell me more, hehe."
+        ]
+    },
+    "brooding_flirt_AJ": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No."
+        ]
+    },
+    "brooding_flirt_AJ1": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "...",
+            "...*Blush*"
+        ]
+    },
+    "brooding_flirt_AJ2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "... You're very sweet. To say that."
+        ]
+    },
+    "brooding_flirt_AJ3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm. Why?"
+        ]
+    },
+    "brooding_flirt_AJ4": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c buries {PRONOUN/t_c/poss} face in {PRONOUN/t_c/poss} paws shyly.]"
+        ]
+    },
+    "brooding_flirt_AJ5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c starts to purr.]"
+        ]
+    },
+    "brooding_flirt_AJ6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do you think I'm so shallow ...?"
+        ]
+    },
+    "brooding_flirt_AJ7": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c narrows {PRONOUN/t_c/poss} eyes suspiciously.]",
+            "What's your angle?"
+        ]
+    },
+    "brooding_flirt_AJ8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding",
+                "unlawful"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "neutral",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uhm ... Have you considered seeing r_d?",
+            "If you're seriously interested in me, you probably have some issues to work through."
+        ]
+    },
+    "brooding_flirt_AJ9": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c allows the faintest hint of a smile to crack over {PRONOUN/t_c/poss} face.]",
+            "... Thank you."
+        ]
+    },
+    "cool_flirt": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Never took you for such a smooth talker, y_c. It's a little unnerving.",
+            "... But, I don't exactly hate it, either. ~"
+        ]
+    },
+    "cool_flirt_AJ": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Echh. Someone get r_m. That was so sincere, I think it's causing an allergic reaction."
+        ]
+    },
+    "cool_flirt_AJ1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Cute. Can I go now?"
+        ]
+    },
+    "cool_flirt_AJ2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, r_q? Remind me how you teach the kits to spell 'Out of your league'?"
+        ]
+    },
+    "cool_flirt_AJ3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Y'know, if I didn't know any better, I'd say you were flirting with me, y_c.~",
+            "Well, why'd you stop? I never said I didn't like it!"
+        ]
+    },
+    "cool_flirt_AJ4": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "cool",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "That was. So lame. Ha.",
+            "[t_c looks away, blushing.]"
+        ]
+    },
+    "cool_flirt_AJ5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Huh. Y'know, that really wasn't half bad.",
+            "Who taught you that line? Was it me?"
+        ]
+    },
+    "cool_flirt_AJ6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_30"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, didn't I teach you that line?"
+        ]
+    },
+    "cool_flirt_AJ7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Testy. I like it."
+        ]
+    },
+    "cool_flirt_AJ8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Feeling's mutual, babe!~"
+        ]
+    },
+    "cool_flirt_AJ9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Heh. Always loved that line."
+        ]
+    },
+    "cool_flirt_AJ10": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Uhm - What is this feeling?",
+            "I'm actually getting ... nervous?",
+            "Is this how regular cats feel all the time?"
+        ]
+    },
+    "oldflirts_84": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "neurotic",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Y-You deserve compliments much more than I do!"
+        ]
+    },
+    "oldflirts_85": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Awee, me? No way, you deserve all these compliments!"
+        ]
+    },
+    "oldflirts_86": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Heh... Thanks..."
+        ]
+    },
+    "oldflirts_87": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Aw, thank you! That's so sweet of you!"
+        ]
+    },
+    "oldflirts_88": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "introspective",
+                "upstanding"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Wow... Your fur is really shiny today...",
+            "Was it always like that?"
+        ]
+    },
+    "oldflirts_89": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Is that so? Well, go on. Tell me more about how wonderful I am."
+        ]
+    },
+    "oldflirts_90": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "silly"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh goodness! You're so sweet!",
+            "Let me try...",
+            "Your fur looks so radiant in the sun today! Almost as radiant as your eyes.",
+            "Did I do good?"
+        ]
+    },
+    "oldflirts_91": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "hGK- Oh my goodness-",
+            "Sorry I wasn't expecting something as smooth as that!"
+        ]
+    },
+    "oldflirts_92": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "AWW!! That's so sweet of you!! You really think of me that way?"
+        ]
+    },
+    "oldflirts_93": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "unabashed"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Heh. I am quite attractive, aren't I? Do go on."
+        ]
+    },
+    "oldflirts_94": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Finally! Someone who noticed."
+        ]
+    },
+    "oldflirts_95": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "At least you have eyes."
+        ]
+    },
+    "oldflirts_96": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "unabashed",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Obviously."
+        ]
+    },
+    "oldflirts_97": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I always look lovely. Are you trying to imply that I don't?"
+        ]
+    },
+    "oldflirts_98": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "R-Really... me? ...",
+            "T... Thanks... it.. It really means a lot."
+        ]
+    },
+    "oldflirts_99": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... That was an awful attempt at flirting, but you are cute, so I'll let it slide."
+        ]
+    },
+    "oldflirts_100": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "... Thanks. I needed to hear that."
+        ]
+    },
+    "oldflirts_101": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Ah- I love you so much."
+        ]
+    },
+    "oldflirts_102": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Hahaha! At least you're funny."
+        ]
+    },
+    "upstanding_reject": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, I just don't have time for something like this right now."
+        ]
+    },
+    "oldflirts_103": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "introspective",
+                "upstanding"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You noticed!? Aw, thank you! I spent extra time grooming my pelt today!"
+        ]
+    },
+    "oldflirts_104": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "silly"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Hehe! You've got something on your face.. Here I'll get it!"
+        ]
+    },
+    "oldflirts_105": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding",
+                "upstanding"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "..Thanks.. Your pelt looks... scruffy today?"
+        ]
+    },
+    "oldflirts_106": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unabashed",
+                "sweet",
+                "stable",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Aw! I love you, too!"
+        ]
+    },
+    "oldflirts_107": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're still just as good at flirting as when we first got together, you know?"
+        ]
+    },
+    "oldflirts_108": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What's your secret? You always know what I need to hear before I do."
+        ]
+    },
+    "oldflirts_109": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Do you have some sort of secret StarClan cat in your dreams telling you how to woo me?",
+            "If so, tell them they're doing a great job."
+        ]
+    },
+    "oldflirts_110": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Awww!! Thank you!"
+        ]
+    },
+    "oldflirts_111": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Wait! Let me try one!",
+            "...",
+            ".....",
+            "Uhhhh...",
+            "You smell like the freshkill I ate this morning! It tasted really really good!"
+        ]
+    },
+    "oldflirts_112": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "sweet",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Aw! Aren't you adorable!"
+        ]
+    },
+    "oldflirts_113": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "If StarClan came for me tomorrow, I would be ready to go, knowing that I got to spend time with a cat as wonderful as you."
+        ]
+    },
+    "oldflirts_114": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate",
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You know, I never knew that I'd end up with a cat like you... But now that I'm here, I wouldn't have it any other way."
+        ]
+    },
+    "oldflirts_115": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "O-Oh! Wow, you're wonderful, you know that, right?"
+        ]
+    },
+    "oldflirts_116": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "biome": [
+            "beach"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I must have sand in my ears... What was that again?"
+        ]
+    },
+    "oldflirts_117": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "biome": [
+            "forest"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Mmm! You smell wonderful, like the forest just after rain!"
+        ]
+    },
+    "oldflirts_118": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I... must agree that was actually neat. Look, I'm surprised."
+        ]
+    },
+    "oldflirts_119": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "introspective",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Uh- you smell good too! Like- catmint and lavender!"
+        ]
+    },
+    "oldflirts_120": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "introspective"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You know, your eyes look just like pools of water when they flash like that.",
+            "Has anyone ever told you that?"
+        ]
+    },
+    "oldflirts_121": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What- uh, thanks! That's really nice of you."
+        ]
+    },
+    "oldflirts_122": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "Okay then. Thanks, I guess."
+        ]
+    },
+    "oldflirts_123": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "introspective"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Really? Well, your eyes are like moonlight!",
+            "And, uhm.. I'm not usually this nervous.. You flatter me."
+        ]
+    },
+    "oldflirts_124": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "silly"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're beautiful like a butterfly, and you sparkle in the moonlight. Was that good, or what?"
+        ]
+    },
+    "oldflirts_125": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Thanks! That's the 15th time someone said I was beautiful today! I'm trying to get to 20!"
+        ]
+    },
+    "oldflirts_126": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "introspective",
+                "neurotic"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "...",
+            "Dear StarClan, I- uhm..",
+            "I'm really not used to this..",
+            "Thank you. You're pretty, too."
+        ]
+    },
+    "oldflirts_127": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Your compliments are like a ray of sunshine in my bleak world."
+        ]
+    },
+    "oldflirts_128": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "silly"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Is it my turn now, hehe?",
+            "You're beautiful like moonlight, and, and, and...",
+            "Your fur is as soft as moss!",
+            "This is fun!"
+        ]
+    },
+    "oldflirts_129": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "deputy",
+                "leader"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're distracting me...",
+            "I need to focus on my duties, but you're too attractive."
+        ]
+    },
+    "oldflirts_130": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "silly",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Arrggh, stop making me feel weird! It feels like there's butterflies in my belly whenever I'm with you as is!"
+        ]
+    },
+    "oldflirts_131": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate",
+            "max_dislike_25"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I knew it. I've got the best mate EVER!"
+        ]
+    },
+    "oldflirts_132": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Thanks, honey. That was really cute even though it was kind of lame..."
+        ]
+    },
+    "oldflirts_133": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't worry! You'll get better one day."
+        ]
+    },
+    "oldflirts_134": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Thank you! I really appreciate it...",
+            "...Y'know, sometimes I doubt if I even deserve to be your mate.",
+            "But I just keep telling myself that you'd tell me if you didn't want to be mates.",
+            "And what you just said made me feel much better!"
+        ]
+    },
+    "oldflirts_135": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You really suck at that, you know? Hah."
+        ]
+    },
+    "oldflirts_136": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "... Oh, stop it. ~"
+        ]
+    },
+    "oldflirts_137": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "About that, I'm sorry for being so..",
+            "...Cold? -- Around you. I've been trying to get better with that sort of thing.",
+            "I guess I just get nervous."
+        ]
+    },
+    "heartbroken_1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "It's kind of you to say that, but my heart is elsewhere."
+        ]
+    },
+    "heartbroken_2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I appreciate the gesture, but I'm not ready for this."
+        ]
+    },
+    "heartbroken_3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "heartbroken_4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I need some time to heal from this heartbreak. Please understand."
+        ]
+    },
+    "heartbroken_5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "heartbroken_6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "It's not about you, it's about where my heart is right now."
+        ]
+    },
+    "heartbroken_7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "heartbroken_8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "heartbroken_9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "heartbroken_10": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That's cool, but I've got other things on my mind."
+        ]
+    },
+    "heartbroken_11": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Life's strange, isn't it? I'm still trying to recover from my last relationship, and yet here you are."
+        ]
+    },
+    "heartbroken_12": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "cool",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Kind words, but I'm walking a solitary path for now."
+        ]
+    },
+    "heartbroken_13": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "heartbroken_14": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Trust is earned. Let's keep things as they are."
+        ]
+    },
+    "heartbroken_15": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "silly",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Tempting, but I'm playing hard to get right now."
+        ]
+    },
+    "heartbroken_16": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "neurotic"
+            ],
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I'm... Taking things slow right now, but thank you."
+        ]
+    },
+    "flirt_sh_J25": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ew. Why would you say that to anycat, given your situation?",
+            "Murderers don't get love, y_c. Stop trying."
+        ]
+    },
+    "flirt_sh_J26": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Please don't say that to me right now."
+        ]
+    },
+    "flirt_sh_J27": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c just blinks at you, trying not to react.]"
+        ]
+    },
+    "flirt_sh_J28": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, darling. Not now."
+        ]
+    },
+    "flirt_sh_J29": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c playfully taps you with {PRONOUN/t_c/poss} tail before pulling it away before anycat can see.]"
+        ]
+    },
+    "flirt_sh_J30": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're very cruel, y_c."
+        ]
+    },
+    "flirt_sh_J31": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "No, no, don't do that. Not now."
+        ]
+    },
+    "flirt_sh_J32": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates",
+            "min_dislike_25",
+            "min_romantic_10"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Maybe I could have liked you if you weren't so evil."
+        ]
+    },
+    "flirt_sh_J33": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, um... Thank you..."
+        ]
+    },
+    "flirt_sh_J34": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J35": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "y_c...?"
+        ]
+    },
+    "flirt_sh_J36": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J37": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What's going on...?"
+        ]
+    },
+    "flirt_sh_J38": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject",
+            "accept"
+        ],
+        "intro": [
+            "Ugh... Not now..."
+        ]
+    },
+    "flirt_sh_J39": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject",
+            "accept"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J40": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "shunned": true,
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject",
+            "accept"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirting_shunned_CM1": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "...... What?",
+            "y_c, oh, y_c. You know what I've done. You can't - we can't... oh no..",
+            "[t_c curls up on the ground, burying {PRONOUN/t_c/poss} face into {PRONOUN/t_c/poss} pelt as {PRONOUN/t_c/poss} muzzle turns red.]"
+        ]
+    },
+    "flirting_shunned_CM2": {
+        "y_c": {},
+        "t_c": {
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c frowns at you, {PRONOUN/t_c/poss} claws pressing out.]",
+            "You're not supposed to be talking to me, nevermind saying stupid things like that."
+        ]
+    },
+    "flirting_shunned_CM3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No.",
+            "Now get lost before I tell l_n all about what you just said to me.",
+            "I'm sure {PRONOUN/l_n/poss} face would be hilarious."
+        ]
+    },
+    "flirting_shunned_Ren1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept",
+            "reject"
+        ],
+        "intro": [
+            "[You approached t_c, quietly starting to flirt with {PRONOUN/t_c/object}.]",
+            "y_c. I murdered neutral-v_c. Why are you talking to me, let alone like this?",
+            "[You tell t_c that you never liked neutral-v_c anyway, and maybe you like a little danger too.]"
+        ]
+    },
+    "flirting_shunned_Ren2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates",
+            "min_dislike_10"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[You decide to start flirting with t_c in an attempt to see where it leads. {PRONOUN/t_c/subject/CAP} {VERB/t_c/do/does} not seem amused.]",
+            "y_c. I murdered v_c. I'm not afraid to go after you too if you keep at it.",
+            "[You try one more time, but t_c lashes out at you, not afraid to get more blood on {PRONOUN/t_c/poss} claws. It seems {PRONOUN/t_c/subject} {VERB/t_c/aren't/isn't} too fond of you.]"
+        ]
+    },
+    "flirting_shunned_SQ3": {
+        "y_c": {
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c backs away, {PRONOUN/t_c/poss} fur bristling.]",
+            "You aren't allowed to <i>talk</i> to me, let alone say something like that.",
+            "I might not be a murderer, but I still know how to use these claws.",
+            "Remember that next time you even <i>think</i> about opening your mouth."
+        ]
+    },
+    "flirt_sh_J41": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J42": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Ugh..."
+        ]
+    },
+    "flirt_sh_J43": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Hehe, I don't think that now is really the time..."
+        ]
+    },
+    "flirt_sh_J44": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time, y_c."
+        ]
+    },
+    "flirt_sh_J45": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Um... no."
+        ]
+    },
+    "flirt_sh_J46": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Maybe later, y_c."
+        ]
+    },
+    "flirting_shunned_SQ4": {
+        "y_c": {
+            "shunned": true
+        },
+        "t_c": {},
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[You call softly to t_c as {PRONOUN/t_c/subject} {VERB/t_c/pass/passes}, and {PRONOUN/t_c/subject} {VERB/t_c/stop/stops} in {PRONOUN/t_c/poss} tracks.]",
+            "I... y_c?",
+            "[Across the camp, l_n pulls away from a discussion with r_w and strides towards you, {PRONOUN/l_n/poss} eyes narrowed.]",
+            "[t_c hastily backs away as {PRONOUN/t_c/subject} also {VERB/t_c/notice/notices} l_n, though you see {PRONOUN/t_c/object} trying to hide {PRONOUN/t_c/poss} smile.]"
+        ]
+    },
+    "flirting_shunned_CM4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "... That gives me an idea, y_c.",
+            "c_n will never see us the same. We'll always be the dirt on their paws because we have blood on our own.",
+            "We should leave, y_c, make something for us - maybe an entire Clan. But I won't leave until you're ready to come with me.",
+            "I couldn't do it alone."
+        ]
+    },
+    "flirting_shunned_SQ1": {
+        "y_c": {
+            "shunned": true
+        },
+        "t_c": {
+            "shunned": true
+        },
+        "relationship": [
+            "min_dislike_10"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares as you for a second, {PRONOUN/t_c/poss} tail lashing.]",
+            "What is wrong with you? Do you think this is some kind of opportunity? Just because the Clan hates us doesn't mean I have to... <i>like</i> you.",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/turn/turns} away, hissing over {PRONOUN/t_c/poss} shoulder.]",
+            "I have other things to worry about, y_c. You should probably get your priorities straight, too."
+        ]
+    },
+    "flirting_shunned_SQ2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[Long after sundown, you and t_c are curled up in your makeshift nests at the edge of camp, but from {PRONOUN/t_c/poss} constant shifting, it's clear {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} having trouble sleeping.]",
+            "[You lean over and rest your head on t_c, whispering to {PRONOUN/t_c/object}. For a moment, {PRONOUN/t_c/subject} {VERB/t_c/seem/seems} frozen, but then {PRONOUN/t_c/subject} {VERB/t_c/press/presses} closer.]",
+            "You... mean that? Even now?",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/curl/curls} {PRONOUN/t_c/poss} tail around you, and you do the same. You stay like that for a while, listening to t_c's breathing and sounds from the camp where neither of you are welcome.]"
+        ]
+    },
+    "grieving_flirt_CM1": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c barely looks up at you, choking out a sob as {PRONOUN/t_c/subject} {VERB/t_c/tremble/trembles}.]",
+            "y_c, y_c I'm sorry. I- <i>hic</i> I can't...",
+            "I can't love anyone like I did plike-tg_c.",
+            "It... if I lost you... it would destroy me if I did."
+        ]
+    },
+    "grieving_flirt_reuse1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "grieving_flirt_reuse2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I need some time to heal. Please understand."
+        ]
+    },
+    "grieving_flirt_reuse3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "grieving_flirt_reuse4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "grieving_flirt_reuse7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "grieving_flirt_Guy1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
+            "How <b>dare</b> you y_c. How dare you think you can replace rlove-tg_c!"
+        ]
+    },
+    "grieving_flirt_reuse11": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "brooding",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Right now, my emotions are too raw for anything more."
+        ]
+    },
+    "grieving_flirt_reuse22": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "sweet",
+                "stable",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I need some time to heal. Please understand."
+        ]
+    },
+    "grieving_flirt_reuse31": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "stable",
+                "introspective",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now's not a good time for me. I hope you get that."
+        ]
+    },
+    "grieving_flirt_reuse42": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse51": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "unlawful"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse62": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "cool",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Well, that's just what I needed. More complicated feelings!"
+        ]
+    },
+    "grieving_flirt_reuse71": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "assertive",
+                "brooding",
+                "upstanding"
+            ],
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Why now? Why me?"
+        ]
+    },
+    "grieving_flirt_Guy21": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c opens {PRONOUN/t_c/poss} maws and snarls at you.]",
+            "How <b>dare</b> you y_c. How dare you think you can replace rlove-tg_c!"
+        ]
+    },
+    "grieving_flirt_reuse432": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse5121": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grieving_flirt_reuse41": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "intro": [
+            "Um, thank you... But I'm... I'm still processing things."
+        ]
+    },
+    "grieving_flirt_reuse511": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Not the time or the place. Move along."
+        ]
+    },
+    "grievingyou_J1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Wh-what?! y_c?!",
+            "I've finally lost my mind.",
+            "But, um... Thank you, ghost."
+        ]
+    },
+    "grievingyou_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I must be going insane. y_c is dead... {PRONOUN/y_c/subject} would never say that..."
+        ]
+    },
+    "grievingthem_J1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "grievingthem"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I love and missed you too, y_c."
+        ]
+    },
+    "grievingthem_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "grievingthem"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're not thinking clearly right now..."
+        ]
+    },
+    "bothgrieving_flirt_J1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "grievingthem",
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't know what's going on anymore."
+        ]
+    },
+    "bothgrieving_flirt_J9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Absolutely not, y_c. Neither of us are in any state for this. Especially you."
+        ]
+    },
+    "bothgrieving_flirt_J10": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Come back later, y_c. Thank you, but I can't do this right now."
+        ]
+    },
+    "flirt_success_H9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "forgiven": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "After all this time... you'll still speak to me so sweetly? Even after everything I've done?",
+            "You're a wonderful cat, y_c. I cannot thank you enough for your forgiveness."
+        ]
+    },
+    "flirt_reject_H6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Do you have a death wish, or is this just to humiliate me?"
+        ]
+    },
+    "flirt_reject_H7": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Get lost, I'm serious.",
+            "[t_c hisses in your direction, {PRONOUN/t_c/poss} tail lashing and claws extending.]"
+        ]
+    },
+    "flirt_reject_H8": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're going to get in trouble, you know that."
+        ]
+    },
+    "flirt_reject_H9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm a murderer and you're still trying to get with me?",
+            "You have some dedication.",
+            "Not-- No, that's not a compliment!"
+        ]
+    },
+    "flirt_reject_H15": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You know, I would be flattered if there was some freshkill sent my way.",
+            "... No? Then you're not worth my time."
+        ]
+    },
+    "flirt_success_H6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Hmm... you amuse me, I'll give you that."
+        ]
+    },
+    "flirt_success_H7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I'll admit, you have bravery saying those things under these circumstances.",
+            "I can't help but feel a bit flattered."
+        ]
+    },
+    "flirt_success_H8": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c looks away, flustered.]",
+            "[Mission accomplished.]"
+        ]
+    },
+    "flirt_reject_H16": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "heartbroken"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I cannot deal with this. Not while my life crumbles so quickly.",
+            "... Is this my karma?"
+        ]
+    },
+    "flirting_shunned_SQ5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you.]",
+            "I'm not even allowed to talk with t_m.",
+            "What makes you think I'd want to talk with you?"
+        ]
+    },
+    "flirt_reject_H17": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You must be a fool to believe I would take kindly to that.",
+            "Scram."
+        ]
+    },
+    "flirt_reject_H18": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'd consider this an insult."
+        ]
+    },
+    "flirt_reject_H10": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "tg_c just died and you're trying to flirt with me?",
+            "... You need to get your priorities in order, y_c. Seriously."
+        ]
+    },
+    "flirt_reject_H13": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
+            "[Your flirting is not welcome, it seems.]"
+        ]
+    },
+    "flirt_Guy1": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "unlawful",
+                "brooding",
+                "introspective"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c rolls {PRONOUN/t_c/poss} eyes and scoffs.]",
+            "Words said so often that they lack any meaning."
+        ]
+    },
+    "flirting_neurotic_SQ1": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shrinks back. {PRONOUN/t_c/subject/CAP} {VERB/t_c/narrow/narrows} {PRONOUN/t_c/poss} eyes at {PRONOUN/t_c/poss} paws.]",
+            "Are you making fun of me? That's not nice, y_c."
+        ]
+    },
+    "flirting_neurotic_SQ2": {
+        "y_c": {},
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "...me?",
+            "[t_c's fur fluffs. {PRONOUN/t_c/poss/CAP} eyes dart from side to side, never quite meeting yours, as if {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} looking for another cat you might have been addressing.]",
+            "T-thank you?"
+        ]
+    },
+    "flirt_success_H1": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Heh, you... you mean that?",
+            "Wow..."
+        ]
+    },
+    "flirt_success_H2": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c's ears go red and {PRONOUN/t_c/poss} eyes light up in awe.]",
+            "[You seem to have broken {PRONOUN/t_c/object} slightly with your awkward flirting.]"
+        ]
+    },
+    "flirt_success_H3": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I thought we were just friends.",
+            "Heh, just kidding. I think you're really cute too."
+        ]
+    },
+    "flirt_success_H4": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_30"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're joking with me.",
+            "N-no? You're not?",
+            "Am I dreaming or is this the luckiest day of my life?"
+        ]
+    },
+    "flirt_reject_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, wrap it up."
+        ]
+    },
+    "flirt_reject_H2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "No, thanks."
+        ]
+    },
+    "flirt_reject_H3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... And what am I supposed to do with this information, exactly?"
+        ]
+    },
+    "flirt_reject_H4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... Right, that made no sense.",
+            "You should work on your flirting a little more before you try again."
+        ]
+    },
+    "flirt_reject_H5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ],
+            "status": [
+                "leader",
+                "deputy"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Uh, sorry I think I just heard r_w calling for me.",
+            "Time to do my duties! Haha... ha...",
+            "[t_c skitters off in a hurry. Was your flirting really that bad?]"
+        ]
+    },
+    "flirt_reject_H11": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hm? What?",
+            "Sorry, I couldn't hear you."
+        ]
+    },
+    "flirt_reject_H12": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "season": [
+            "leafbare"
+        ],
+        "relationship": [
+            "min_platonic_15"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "What are you doing outside? It's so cold!",
+            "[t_c coaxes you back to somewhere warm. Alas, your attempt at flirting either went over {PRONOUN/t_c/poss} head... or was ignored.]",
+            "[You can't decide which one is worse.]"
+        ]
+    },
+    "flirt_reject_H14": {
+        "y_c": {
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "blind:any:false",
+                "heartbroken"
+            ],
+            "shunned": "any"
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's tail lashes angrily and {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} the other way.]",
+            "[Your flirting is not welcome, it seems.]"
+        ]
+    },
+    "flirt_reject_H19": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You have some nerve..."
+        ]
+    },
+    "blind_to_grieving_H1": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't understand how you can flirt with me right now!",
+            "[t_c bursts into tears and buries {PRONOUN/t_c/poss} head underneath {PRONOUN/t_c/poss} paws.]"
+        ]
+    },
+    "deafflirt_J1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[While laying next to t_c in camp, you reach your paw towards {PRONOUN/t_c/inposs}.]",
+            "[{PRONOUN/t_c/poss/CAP} blush is so strong that you can feel it!]"
+        ]
+    },
+    "deafflirt_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[While laying next to t_c in camp, you reach your paw towards {PRONOUN/t_c/inposs}.]",
+            "[{PRONOUN/t_c/subject/CAP} quickly {VERB/t_c/flinch/flinches} and {VERB/t_c/shuffle/shuffles} away from you.]"
+        ]
+    },
+    "hasmate_success_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Don't tell t_m, but your flirting is a lot better than {PRONOUN/t_m/inposs}."
+        ]
+    },
+    "hasmate_success_H2": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_20",
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You have a lot of nerve.",
+            "[Despite t_c's words, {PRONOUN/t_c/subject} {VERB/t_c/turn/turns} to hide a smile.]"
+        ]
+    },
+    "hasmate_success_H3": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c turns away, flustered by your flirting.]",
+            "[Just over {PRONOUN/t_c/poss} shoulder, you see t_m watching from the distance, {PRONOUN/t_m/poss} tail lashing.]",
+            "[... Whoops.]"
+        ]
+    },
+    "hasmate_success_H4": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, do you mean that?",
+            "[t_m calls for t_c in the distance. t_c almost jumps out of {PRONOUN/t_c/poss} fur in guilty surprise.]",
+            "Sorry, gotta go! I'll talk to you later!"
+        ]
+    },
+    "hasmate_success_H5": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_20"
+        ],
+        "tags": [
+            "accept",
+            "has_mate"
+        ],
+        "intro": [
+            "Does everycat want a piece of me, or what?",
+            "[t_c's chest puffs out, smug from all the attention.]"
+        ]
+    },
+    "hasmate_success_H6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_20",
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, t_m beat you to it! Maybe next moon *wink*."
+        ]
+    },
+    "flirt_reject_H20": {
+        "y_c": {},
+        "t_c": {},
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, y_c! Thank you! Do you know who else has gorgeous eyes?",
+            "theircrush!~",
+            "[t_c sighs blissfully.]"
+        ]
+    },
+    "flirt_reject_H21": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh, I wish theircrush spoke to me like that!"
+        ]
+    },
+    "flirt_reject_H22": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're really nice, y_c, but...",
+            "I can't get over theircrush. I hope you understand!"
+        ]
+    },
+    "flirt_reject_H23": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {},
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Sorry, y_c but... I have my eyes set out for theircrush."
+        ]
+    },
+    "flirt_reject_H24": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "medicine cat"
+            ]
+        },
+        "relationship": [
+            "min_dislike_50"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I would rather chew on ragwort than flirt with you."
+        ]
+    },
+    "flirt_reject_H25": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "queen",
+                "queen's apprentice"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20"
+        ],
+        "tags": [
+            "reject",
+            "clan_has_kits"
+        ],
+        "intro": [
+            "I'm really busy with the kits right now, sorry! I'll talk to you later?"
+        ]
+    },
+    "flirt_reject_H26": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "mediator"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "... This is a weird way to ask for mediation."
+        ]
+    },
+    "flirt_reject_H27": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "status": [
+                "warrior"
+            ],
+            "min_max_faith": [
+                0,
+                9
+            ]
+        },
+        "relationship": [
+            "min_dislike_50"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "StarClan, do I need to ask d_n to set me out on more patrols so you'll stop flirting with me?"
+        ]
+    },
+    "hasmate_reject_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "That was a nice attempt, but I am very happy with t_m."
+        ]
+    },
+    "hasmate_reject_H2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c laughs loudly at your flirting.]",
+            "Haha, good one, y_c! Oh, I can't wait to pass your joke to t_m!"
+        ]
+    },
+    "hasmate_reject_H3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Are you joking? You must be joking.",
+            "... you know I'm happily in a relationship with t_m... right?"
+        ]
+    },
+    "hasmate_reject_H4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_30",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Back off before I call t_m over."
+        ]
+    },
+    "hasmate_reject_H5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_30",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you, unamused with your flirting.]",
+            "Stop that! Don't you know I'm with t_m?"
+        ]
+    },
+    "hasmate_reject_H6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject",
+            "has_mate"
+        ],
+        "intro": [
+            "Sorry, you're definitely not my type of cat."
+        ]
+    },
+    "hasmate_reject_H7": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "has_mate",
+            "reject"
+        ],
+        "intro": [
+            "What?",
+            "Oh. Sorry, you're nothing like the <i>love of my life</i>.",
+            "Do you get the hint, or..."
+        ]
+    },
+    "hasmate_reject_H8": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Look, y_c, do you not see how happy I am with t_m?",
+            "You can't separate me from {PRONOUN/t_m/object}, but good luck trying."
+        ]
+    },
+    "hasmate_reject_H9": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh uh, I just remembered that I need to do something!",
+            "With t_m, yup!",
+            "[t_c skitters off in a hurry.]"
+        ]
+    },
+    "hasmate_reject_H10": {
+        "y_c": {},
+        "t_c": {
+            "status": [
+                "deputy"
+            ]
+        },
+        "relationship": [
+            "non-mates",
+            "min_dislike_10"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c narrows {PRONOUN/t_c/poss} eyes at you, thoughtful.]",
+            "y_c, you are very brave, I'll give you that.",
+            "Oh, you know what? Since you're so brave, how about I place you on more border patrols?"
+        ]
+    },
+    "frommate_grieving_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm sorry, y_c, I'm... not in the mood right now."
+        ]
+    },
+    "frommate_grieving_H2": {
+        "y_c": {},
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Haha...",
+            "You always know what to say to cheer me up.",
+            "[t_c smiles, but you can still see the deep sadness in {PRONOUN/t_c/poss} eyes.]"
+        ]
+    },
+    "frommate_grieving_H3": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c smiles at you, but it's clear {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} not in the mood for flirting.]"
+        ]
+    },
+    "grieving_H1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c curls in a ball, ignoring your attempts to flirt.]"
+        ]
+    },
+    "frommate_reject_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "y_c, I'm not in the mood."
+        ]
+    },
+    "frommate_reject_H2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "y_c... is it just me or did your flirting become worse over the moons we've been together?",
+            "Oh... Yes, I am totally joking! Haha... ha..."
+        ]
+    },
+    "frommate_reject_H3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You must not mean that."
+        ]
+    },
+    "frommate_reject_H4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Awh! I can tell you've been... practicing that one!",
+            "Oh. You didn't? Uhem.",
+            "Ah -- Of course, I knew that! You're very... good. At flirting."
+        ]
+    },
+    "frommate_reject_H5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I'm going to be honest.",
+            "That was the worst, y_c."
+        ]
+    },
+    "guiltyblind_flirt_H1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false",
+                "guilt"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c curls in a ball, ignoring your attempts to flirt.]"
+        ]
+    },
+    "guiltyblind_flirt_H2": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false",
+                "guilt"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c gives you an awkward smile, flushed by your actions.]"
+        ]
+    },
+    "guiltyblind_flirt_H3": {
+        "y_c": {
+            "status": [
+                "any"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "guilt"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Ah... I'm not feeling well right now, y_c.",
+            "Maybe later?"
+        ]
+    },
+    "youdeaf_R81": {
+        "y_c": {
+            "condition": [
+                "deaf:any:true"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [
+            "min_romantic_10"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c sees the flower you have and {PRONOUN/t_c/poss} eyes light up. {PRONOUN/t_c/subject/CAP} {VERB/t_c/motion/motions} the sign for 'thank you' with {PRONOUN/t_c/poss} head high, ears fluttering, and {PRONOUN/t_c/poss} whiskers twitching.]"
+        ]
+    },
+    "youdeaf_R82": {
+        "y_c": {
+            "condition": [
+                "deaf:any:true"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[Flirting might be harder without words, but it's worth it.]",
+            "[At least, t_c seems to appreciate your efforts as you can feel the purr rumbling {PRONOUN/t_c/poss} chest!]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/walk/walks} away with {PRONOUN/t_c/poss} head held high after.]"
+        ]
+    },
+    "youdeaf_R83": {
+        "y_c": {
+            "condition": [
+                "deaf:any:true"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "silly",
+                "neurotic"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/duck/ducks} {PRONOUN/t_c/poss} head shyly in response.]"
+        ]
+    },
+    "youdeaf_R84": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c frowns a little at your flirting attempt. {PRONOUN/t_c/subject/CAP} {VERB/t_c/turn/turns} away without a response.]"
+        ]
+    },
+    "youdeaf_R85": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem to know how to respond.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_01": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh... really? Huh, no one has ever said that to me before... Thank you- I'm sorry I don't really know what to say.",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/let/lets} out a chuckle, {PRONOUN/t_c/poss} whiskers twitching slightly as {PRONOUN/t_c/subject} {VERB/t_c/try/tries} to hide {PRONOUN/t_c/poss} growing smile.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_02": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false",
+                "hearing"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "!!!",
+            "I think I hear my training calling me- foxdung! I meant my mentor! Because training is a task and you can't hear a task- that's so stupid! Hahaha! Yeah I hear my train- I mean my...",
+            "SEE YOU LATER!",
+            "[t_c darts away, {PRONOUN/t_c/poss} fur on end- you swear you can see the tips of {PRONOUN/t_c/poss} ears turn red.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_03": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Did your mentor teach you to flirt like that? Maybe I should ask tm_n if {PRONOUN/tm_n/subject} {VERB/tm_n/have/has} any tips...Because that right there, that is a life skill."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_04": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Woah, is this how adults feel? When they have mates... I suddenly feel all light and hot all the sudden...",
+            "Quickly! Say something else! I need to know if this is normal!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_05": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Maybe being friends can go somewhere else... That doesn't sound too bad... What do you think?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_06": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Since when did you get so smooth? I thought we were friends, you keeping these super cool and overpowered flirting skills a secret from me?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_07": {
+        "y_c": {
+            "cluster": [
+                "introspective",
+                "neurotic"
+            ],
+            "age": [
+                "adolescent"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "cool",
+                "upstanding"
+            ],
+            "age": [
+                "adolescent"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50",
+            "min_romantic_10",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "If you think I'm pretty, take a look at yourself.",
+            "GAH!",
+            "I mean that as a friend in a platonic way because if that was meant to be romantic then... You know what? Forget it, you y_c, are beautiful like a ray of sunshine and it bothers me that you don't see it.",
+            "...",
+            "You're very pretty."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_08": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_30",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're too kind, y_c... I'm so happy to be your friend and maybe... maybe one day, something... more..."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_09": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ]
+        },
+        "relationship": [
+            "min_platonic_40",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "HA! Good one!",
+            "Wait- are you serious? You are?",
+            "[t_c's ears raise up higher, a grin on {PRONOUN/tm_n/poss} face as {PRONOUN/tm_n/poss} eyes light up.]",
+            "Thank you, y_c!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_10": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "If you distract my training with your sweet words then I'm going to steal your share of the freshkill later. I hate the fact that I love you.",
+            "...",
+            "AS A FRIEND!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_11": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "cool",
+                "brooding"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_30",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Please don't ever change, y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_GenApp_TheyNotMate_12": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "unabashed",
+                "stable"
+            ],
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50",
+            "min_romantic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Is this the origins of our love story? Please say yes!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_01": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're too nice, y_c... Wow, yeah... Way too nice- I don't deserve such wonderful words. You on the other paw, you deserve all the praise."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_02": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Thank you. That means a lot, your words will help me get through today. Thank you y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_03": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "...",
+            "You... You shouldn't say such things...",
+            "I cannot afford to get distracted... Not by a cat such as yourself...",
+            "...",
+            "You're- I need to go.",
+            "[Before you can object, t_c stumbles away, {PRONOUN/t_c/poss} eyes lowered to the ground. You can't help but feel your words are going to stick with {PRONOUN/t_c/object} for a while.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_04": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "A cat like me doesn't deserve this praise.",
+            "You're the beautiful one here, strong, intelligent, kind and capable... Beautiful..."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_05": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "When did you become so... articulate?"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_06": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Is that something normal for a friend to say?",
+            "Because I feel that maybe you said that with- flirtatious intentions...",
+            "But, we're friends though, aren't we?",
+            "Unless... You want to be more?",
+            "[{PRONOUN/t_c/poss/CAP} whiskers twitch slightly as {PRONOUN/t_c/subject} smile, {PRONOUN/t_c/poss} eyes full of unexplainable emotions... Maybe {PRONOUN/t_c/subject} also want to be more than friends? You both can't help but wonder what the future holds.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_07": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I love you too, y_c! I always have and I always will.",
+            "You look a little flushed there, don't worry- I meant what I said. I'll leave you to ponder that thought!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_08": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh- Stop it you! You're going to make me lose concentration!"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_09": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "min_platonic_20",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Says the cat with the stars in {PRONOUN/y_c/poss} eyes and paws as gentle as the river banks. You're the beautiful one here, y_c. Not even Silverpelt could compare to the sight you behold."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_TheyNotMate_10": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "min_platonic_50",
+            "non-mates"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "... Say that again, please. I need to hear it to make sure I heard it correctly.",
+            "Oh... it was what I heard, I'm glad we share the same sentiment."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_01": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Says the cat with the stars in {PRONOUN/y_c/poss} eyes and paws as gentle as the river banks. You're the beautiful one here, y_c. Not even Silverpelt could compare to the sight you behold."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_02": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Not a day goes past where I am not thankful to be welcomed by your embrace... You're perfect, mind, body and soul. I love you y_c."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_03": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Still as sharp as before we got together, aren't you, love?",
+            "Well, please don't stop there, surely there's more you have to say~ If not, I could talk for a little while."
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_04": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Please, never leave my side y_c. I love you dearly, your words are a blessing to be heard. I never want that to be taken away from me.",
+            "[You assure t_c that you'll never leave {PRONOUN/t_c/poss} side. {PRONOUN/t_c/subject/CAP} curls closer to you in your shared bed and begins to purr. You groom {PRONOUN/t_c/poss} fur and whisper soft words of affection- soft enough so only the both of you can hear.]"
+        ]
+    },
+    "TinyTeddy_stable_Flirting_Gen_From Mate_05": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "stable"
+            ],
+            "age": [
+                "adult"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "GAH-",
+            "Love, I- pft!",
+            "[t_c explodes into a fit of giggles.]",
+            "You always know what to say."
+        ]
+    },
+    "neurotic_flirt_SQ3": {
+        "y_c": {
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "relationship": [
+            "max_dislike_5"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c giggles, then looks embarrassed.]",
+            "S-sorry! I... um... That was really sweet...",
+            "[t_c smiles shyly, then scurries away.]"
+        ]
+    },
+    "neurotic_flirt_SQ4": {
+        "y_c": {
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "relationship": [
+            "max_dislike_5"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I... I think you look really nice, too!",
+            "[t_c says the words very quickly, then hightails it to the other side of camp.]"
+        ]
+    },
+    "neurotic_flirt_SQ5": {
+        "y_c": {
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "neurotic"
+            ],
+            "age": [
+                "adolescent",
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Oh! Um...",
+            "[t_c freezes, casting {PRONOUN/t_c/poss} gaze around camp.]",
+            "Ah... sorry, what did you say?",
+            "Oh, actually, tm_n needs to talk to me about an assessment... right now, it looks like! Sorry, I'll see you later!"
+        ]
+    },
+    "niche_situations_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "niche_situations_H2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken",
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "niche_situations_H4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H5": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c purrs as you cuddle up against {PRONOUN/t_c/object}. t_c seems to appreciate the distraction from {PRONOUN/t_c/poss} grief.]"
+        ]
+    },
+    "niche_situations_H6": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c hisses at you when you approach. You can feel {PRONOUN/t_c/poss} disappointment radiating off {PRONOUN/t_c/object}.]"
+        ]
+    },
+    "flirt_SAM1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[You trot up to t_c and rub heads with {PRONOUN/t_c/poss}, earning a small blush.]",
+            "[t_c is seen grinning like a fool afterwards, but {PRONOUN/t_c/subject} {VERB/t_c/try/tries} to hide it.]"
+        ]
+    },
+    "murder_flirt_J1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "reject",
+            "murder_victim",
+            "murder_fail"
+        ],
+        "intro": [
+            "Umm....",
+            "I'm getting very mixed signals from you lately, y_c."
+        ]
+    },
+    "murder_flirt_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "cluster": [
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "accept",
+            "accomplice_agreed"
+        ],
+        "intro": [
+            "Hehehe... I think we make a great team, too, y_c~!"
+        ]
+    },
+    "newshunned_flirt_J1": {
+        "y_c": {
+            "shunned": true
+        },
+        "t_c": {
+            "cluster": [
+                "brooding"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "max_platonic_10"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hm? Are you really bored enough to try hitting on me?",
+            "Yeesh. There's gotta be better things for you to do. Go try drawing in the dirt, or something. I'm not that desperate yet."
+        ]
+    },
+    "newshunned_flirt_J2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "neutral"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I don't find murderers very attractive, y_c. Sorry."
+        ]
+    },
+    "newshunned_flirt_J3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "cluster": [
+                "stable",
+                "silly"
+            ],
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Oh, hush! Even now, you're finding a way to make me smile.",
+            "How do you do it?"
+        ]
+    },
+    "youshunned_flirt_rad1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true,
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You take 'heartstopper' both literally and figuratively, huh?"
+        ]
+    },
+    "accomplice_flirt_reject_rad1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "accomplice_agreed",
+            "reject"
+        ],
+        "intro": [
+            "I agreed to be your partner in crime, not your partner in life."
+        ]
+    },
+    "flirt_accomplicereject_rad1": {
+        "y_c": {
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "not_kitten"
+            ]
+        },
+        "tags": [
+            "accomplice_refused",
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares at you in confusion.]",
+            "You have a <i>weird</i> way of trying to flatter me."
+        ]
+    },
+    "you_shunned_flirt_E1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_30"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c recoils with a hiss.]"
+        ]
+    },
+    "you_shunned_flirt_E2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [
+            "max_platonic_25",
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c blatantly ignores you, barely even twitching an ear as {PRONOUN/t_c/subject} {VERB/t_c/pad/pads} by.]",
+            "[It's like you're invisible.]"
+        ]
+    },
+    "they_shunned_flirt_E1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "relationship": [
+            "min_romantic_20"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "There's a time and a place, y_c. This isn't either of those."
+        ]
+    },
+    "flirt_app_reject_rad1": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c looks away, but {PRONOUN/t_c/poss} face clearly reveals {PRONOUN/t_c/poss} discomfort.]",
+            "[... Not the reaction you'd hoped for.]"
+        ]
+    },
+    "flirt_app_reject_rad2": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "...",
+            "[Judging by the lengthy pause, you suspect t_c feels extremely uncomfortable.]",
+            "[You don't blame {PRONOUN/t_c/object}. You feel uncomfortable now, too.]"
+        ]
+    },
+    "flirt_app_reject_rad3": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c backs away, eyes averted.]"
+        ]
+    },
+    "flirt_app_reject_rad4": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c stares at you blankly.]"
+        ]
+    },
+    "flirt_app_reject_rad5": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c looks at you uncertainly, as though {PRONOUN/t_c/subject}{VERB/t_c/'re/'s} hoping you aren't serious.]"
+        ]
+    },
+    "flirt_app_reject_rad6": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c's eyes are fixed on theircrush across camp.]",
+            "... Oh, sorry, y_c! What were you saying?"
+        ]
+    },
+    "flirt_app_reject_rad7": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ],
+            "skill": [
+                "TUNNELER,1"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[As you and t_c are sharing tongues, you nervously shift to press yourself against {PRONOUN/t_c/subject} pelt.]",
+            "[t_c stiffens, then pulls away.]",
+            "[... You're tempted to go hide in the nearest tunnel for the next few moons until the embarrassment wears off.]"
+        ]
+    },
+    "flirt_app_reject_rad8": {
+        "y_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adolescent"
+            ],
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[After what feels like moons of working up the courage, you gingerly run your tail over t_c's shoulders.]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/jerk/jerks} away sharply, leaving your entire pelt burning with embarrassment.]"
+        ]
+    },
+    "flirt_jfstick_reject_rad1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ],
+            "status": [
+                "medicine cat"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c seems too fixated on a stick to even notice you.]"
+        ]
+    },
+    "deafgrievingflirt_SQ1": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adult"
+            ],
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept",
+            "reject"
+        ],
+        "intro": [
+            "[You press against t_c. {PRONOUN/t_c/subject/CAP} {VERB/t_c/keep/keeps} {PRONOUN/t_c/poss} eyes closed, but press back against you.]",
+            "[You think you hear a small purr, but it quickly turns to sobs.]"
+        ]
+    },
+    "deafgrievingflirt_SQ2": {
+        "y_c": {
+            "age": [
+                "adult"
+            ]
+        },
+        "t_c": {
+            "age": [
+                "adult"
+            ],
+            "condition": [
+                "deaf:any:true",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c lifts {PRONOUN/t_c/poss} head to look at you. {PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} initially react to your signs, so you try again.]",
+            "[...Your mate just sighs and drops {PRONOUN/t_c/poss} head back on {PRONOUN/t_c/poss} paws, sniffling.]"
+        ]
+    },
+    "flirt_sam2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:true"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c presses {PRONOUN/t_c/poss} pelt into yours so that you can feel {PRONOUN/t_c/poss} purrs.]"
+        ]
+    },
+    "shunned_deaf_flirt_H1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c smiles slightly. Even though {PRONOUN/t_c/subject} {VERB/t_c/seem/seems} hesitant, t_c doesn't appear to hate your flirting.]"
+        ]
+    },
+    "shunned_deaf_flirt_H2": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ],
+            "shunned": true
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c turns {PRONOUN/t_c/poss} head away and lashes {PRONOUN/t_c/poss} tail.]",
+            "[{PRONOUN/t_c/subject/CAP} {VERB/t_c/don't/doesn't} seem impressed.]"
+        ]
+    },
+    "shunned_grieving_flirt_H1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "min_dislike_10",
+            "non-mates"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Go away!"
+        ]
+    },
+    "shunned_grieving_flirt_H2": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I do not want to speak with you right now, y_c.",
+            "Please, leave me to grieve."
+        ]
+    },
+    "shunned_grieving_flirt_H4": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "I do not want to speak with you right now, y_c.",
+            "Please, leave me to grieve."
+        ]
+    },
+    "shunned_grieving_flirt_H3": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Don't you think you have caused me enough suffering? I do not need your awful flirting on top of it."
+        ]
+    },
+    "deaf_grieving_flirt_H1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false",
+                "grief stricken"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false"
+            ]
+        },
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "deaf_grieving_H1": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "deaf_grieving_H2": {
+        "y_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shakes {PRONOUN/t_c/poss} head, eyes shining with disappointment.]",
+            "[It's not the time for flirting.]"
+        ]
+    },
+    "flirt_hate_sam1": {
+        "y_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ],
+            "min_max_faith": [
+                0,
+                9
+            ]
+        },
+        "relationship": [
+            "min_dislike_40"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "What in StarClan?",
+            "I-I hate you! I don't like you like that!",
+            "[t_c scurries away, {PRONOUN/t_c/poss} pelt burning with embarrassment.]",
+            "[Maybe t_c doesn't hate you after all.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H1": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {},
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're so pretty even when you cry."
+        ]
+    },
+    "mcgrievingonly_flirting_H2": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're being really sweet, but take care of yourself, yeah?",
+            "How about we visit yg_c later?"
+        ]
+    },
+    "mcgrievingonly_flirting_H3": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {},
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Has anycat ever told you to look ugly when you cry?"
+        ]
+    },
+    "mcgrievingonly_flirting_H6": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Are you using flirting as a coping mechanism?"
+        ]
+    },
+    "mcgrievingonly_flirting_H4": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "non-mates",
+            "min_platonic_20"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Hey, uh, sorry, but I think you should be reflecting in your feelings before flirting with anycat. You know, think about yourself first."
+        ]
+    },
+    "mcgrievingonly_flirting_H5": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "I think that's the most heartfelt thing you've said in a while. Are you feeling feverish or something?",
+            "Hehe, just kidding."
+        ]
+    },
+    "mcgrievingonly_flirting_H7": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": true
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [
+            "min_dislike_25"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Did yg_c going to StarClan make you finally realize you like me?"
+        ]
+    },
+    "mcgrievingonly_flirting_c": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "There's something beautiful about how much you miss them."
+        ]
+    },
+    "mcgrievingonly_flirting_c2": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "The way you loved yg_c...",
+            "It does make me wonder what it would feel to be loved like that too."
+        ]
+    },
+    "mcgrievingonly_flirting_c3": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c shuffles their paws, not meeting your eyes.]",
+            "[It doesn't feel entirely appropriate to accept your advances, not when you're missing yg_c so much.]"
+        ]
+    },
+    "bothgrieving_flirt_H1": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "You're a nice distraction."
+        ]
+    },
+    "bothgrieving_flirt_H2": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "Determined to distract the both of us from our grievances, huh?",
+            "I won't complain."
+        ]
+    },
+    "bothgrieving_flirt_H3": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "Now is not the time, y_c..."
+        ]
+    },
+    "bothgrieving_flirt_H4": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false"
+            ],
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false",
+                "blind:any:false"
+            ],
+            "shunned": "any"
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c avoids your flirting by sitting with {PRONOUN/t_c/poss} back facing you.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H8": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false",
+                "blind:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "blind:any:false",
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [
+            "from_mate"
+        ],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c decides to cuddle with you instead of encouraging the flirting, hoping to make you feel better.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H9": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "accept"
+        ],
+        "intro": [
+            "[t_c smiles, taking your flirting in stride.]"
+        ]
+    },
+    "mcgrievingonly_flirting_H10": {
+        "y_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c smiles, but {PRONOUN/t_c/subject} {VERB/t_c/look/looks} a little awkward around the eyes.]"
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H1": {
+        "y_c": {
+            "shunned": "any",
+            "condition": [
+                "deaf:any:false"
+            ]
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken",
+                "deaf:any:false",
+                "blind:any:false"
+            ]
+        },
+        "relationship": [],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "[t_c ignores you with a flick of {PRONOUN/t_c/poss} tail.]"
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H2": {
+        "y_c": {
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken"
+            ],
+            "skill": [
+                "STAR,1",
+                "DARK,1",
+                "GHOST,1"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject"
+        ],
+        "intro": [
+            "You're not real, you're not real, you're not real."
+        ]
+    },
+    "mcshunned_theygrieving_flirting_H3": {
+        "y_c": {
+            "shunned": "any"
+        },
+        "t_c": {
+            "condition": [
+                "grief stricken"
+            ]
+        },
+        "relationship": [
+            "grievingyou"
+        ],
+        "tags": [
+            "reject",
+            "accept"
+        ],
+        "intro": [
+            "Is my mind playing tricks on me?"
+        ]
+    }
+}

--- a/scripts/events_module/dialogue/reformat/reformat_dialogue.py
+++ b/scripts/events_module/dialogue/reformat/reformat_dialogue.py
@@ -150,6 +150,9 @@ for dkey, dialogue_block in dialogue_json.items():
                                 new_murder_dict[item][item2] = convert[item][item2]
                         else:
                             new_murder_dict[item] = convert[item]
+                else:
+                    if tag == "reject":
+                        TAGS.append("reject")
 
             for new_item in new_murder_dict.copy():
                 if isinstance(new_murder_dict[new_item], dict):
@@ -396,14 +399,14 @@ for dkey, dialogue_block in dialogue_json.items():
                     item.pop(constraint)
 
         new_block["cats"][key] = item
-    if TAGS:
-        new_block["tags"] = TAGS
     if RELATIONSHIPS:
         new_block["relationships"] = RELATIONSHIPS
     
     if MURDER:
         new_block["recent_murder"] = MURDER
 
+    if TAGS:
+        new_block["tags"] = TAGS
     for key, item in SCENES.items():
         new_block[key] = item
 

--- a/scripts/events_module/filter_random_cats.py
+++ b/scripts/events_module/filter_random_cats.py
@@ -253,7 +253,7 @@ def __filter_rank(abbrev_block, cat):
         ):
         if cat not in (game.clan.instructor, game.clan.demon):
             return False
-    elif any(rank in abbrev_block["rank"] for rank in [CatRank.WARRIOR, CatRank.APPRENTICE]):
+    elif abbrev_block['rank']:
         if (
             cat.status.rank not in abbrev_block["rank"] and
             cat.status.rank.replace(' ', '_') not in abbrev_block["rank"]

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -1920,18 +1920,18 @@ class MakeClanScreen(Screens):
         # scars for conditions
         self.custom_cat.pelt.paralyzed = True if self.permanent_condition == "paralyzed" else False
         if self.permanent_condition == "born without a tail":
-            self.custom_cat.pelt.scars = ["NOTAIL"]
+            self.custom_cat.pelt.scars = ("NOTAIL",)
         elif self.permanent_condition == "born without a leg":
-            self.custom_cat.pelt.scars = ["NOPAW"]
+            self.custom_cat.pelt.scars = ("NOPAW",)
         elif self.permanent_condition == "blind":
             if random.randint(0,10) == 1:
                 self.custom_cat.pelt.scars = ["BOTHBLIND"]
         elif self.permanent_condition == "one bad eye":
             if random.randint(0,10) == 1:
-                self.custom_cat.pelt.scars = [random.choice(["LEFTBLIND", "RIGHTBLIND", "BRIGHTHEART"])]
+                self.custom_cat.pelt.scars = (random.choice(["LEFTBLIND", "RIGHTBLIND", "BRIGHTHEART"]),)
         elif self.permanent_condition in ["deaf", "partial hearing loss"]:
             if random.randint(0,10):
-                self.custom_cat.pelt.scars = [random.choice(["LEFTEAR", "RIGHTEAR", "NOEAR"])]
+                self.custom_cat.pelt.scars = (random.choice(["LEFTEAR", "RIGHTEAR", "NOEAR"]),)
 
         self.faith = random.choice(["flexible", "starclan", "dark forest", "neutral"])
 
@@ -3215,23 +3215,23 @@ class MakeClanScreen(Screens):
                             self.custom_cat.pelt.paralyzed = True
 
                         if self.permanent_condition == "born without a leg":
-                            self.custom_cat.pelt.scars = ["NOPAW"]
+                            self.custom_cat.pelt.scars = ("NOPAW",)
                         else:
                             if "NOPAW" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOPAW")
+                                self.custom_cat.pelt.scars = tuple()
 
                         if self.permanent_condition == "born without a tail":
-                            self.custom_cat.pelt.scars = ["NOTAIL"]
+                            self.custom_cat.pelt.scars = ("NOTAIL",)
                         else:
                             if "NOTAIL" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOTAIL")
+                                self.custom_cat.pelt.scars = tuple()
                         
                         if self.permanent_condition != "blind":
                             if "BOTHBLIND" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("BOTHBLIND")
+                                self.custom_cat.pelt.scars = tuple()
                         if self.permanent_condition != "one bad eye":
                             if any(scar in ["LEFTBLIND", "RIGHTBLIND", "BRIGHTHEART"] for scar in self.custom_cat.pelt.scars):
-                                self.custom_cat.pelt.scars = []
+                                self.custom_cat.pelt.scars = tuple()
                     elif self.current_selection == "trait":
                         traits = ['unruly','shy','impulsive','bullying','attention-seeker','daydreamer','charming','fearless','skittish','quiet','self-conscious','know-it-all','sweet','polite','bossy','noisy','smug','secretive','grumpy','manipulative','leader-like','passionate','disciplined','patient','rebellious','honest']
                         current_index = traits.index(self.personality)
@@ -3290,7 +3290,7 @@ class MakeClanScreen(Screens):
                     elif self.current_selection == "skin":
                         self.custom_cat.pelt.skin = random.choice(Pelt.skin_sprites)
                     elif self.current_selection == "scar":
-                        self.custom_cat.pelt.scars = [random.choice(Pelt.all_scars)]
+                        self.custom_cat.pelt.scars = (random.choice(Pelt.all_scars),)
                     elif self.current_selection == "accessory":
 
                         acc_list = (self.all_accs)
@@ -3323,15 +3323,15 @@ class MakeClanScreen(Screens):
 
                         self.permanent_condition = random.choice(permanent_conditions)
                         if self.permanent_condition == "born without a leg":
-                            self.custom_cat.pelt.scars = ["NOPAW"]
+                            self.custom_cat.pelt.scars = ("NOPAW",)
                         else:
                             if "NOPAW" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOPAW")
+                                self.custom_cat.pelt.scars = tuple()
                         if self.permanent_condition == "born without a tail":
-                            self.custom_cat.pelt.scars = ["NOTAIL"]
+                            self.custom_cat.pelt.scars = ("NOTAIL",)
                         else:
                             if "NOTAIL" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOTAIL")
+                                self.custom_cat.pelt.scars = tuple()
                         if self.permanent_condition == "paralyzed":
                             self.custom_cat.pelt.paralyzed = True
                         else:
@@ -3535,9 +3535,9 @@ class MakeClanScreen(Screens):
                 for i in self.scar_buttons.items():
                     if event.ui_element == self.scar_buttons[i[0]]:
                         if i[0] == "None":
-                            self.custom_cat.pelt.scars = []
+                            self.custom_cat.pelt.scars = tuple()
                         else:
-                            self.custom_cat.pelt.scars = [i[0].upper()]
+                            self.custom_cat.pelt.scars = (i[0].upper(),)
                             if i[0] == "NOPAW":
                                 self.permanent_condition = "born without a leg"
                                 self.custom_cat.pelt.paralyzed = False
@@ -3573,17 +3573,17 @@ class MakeClanScreen(Screens):
                         if i[0] == "None":
                             self.permanent_condition = None
                             if "NOTAIL" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOTAIL")
+                                self.custom_cat.pelt.scars = tuple()
                             if "NOPAW" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("NOPAW")
+                                self.custom_cat.pelt.scars = tuple()
                             if "BRIGHTHEART" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("BRIGHTHEART")
+                                self.custom_cat.pelt.scars = tuple()
                             if "BOTHBLIND" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("BOTHBLIND")
+                                self.custom_cat.pelt.scars = tuple()
                             if "LEFTBLIND" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("LEFTBLIND")
+                                self.custom_cat.pelt.scars = tuple()
                             if "RIGHTBLIND" in self.custom_cat.pelt.scars:
-                                self.custom_cat.pelt.scars.remove("RIGHTBLIND")
+                                self.custom_cat.pelt.scars = tuple()
                             self.custom_cat.pelt.paralyzed = False
                         else:
                             if i[0] != "paralyzed":
@@ -3592,23 +3592,23 @@ class MakeClanScreen(Screens):
                                 self.custom_cat.pelt.paralyzed = True
 
                             if i[0] == "born without a leg":
-                                self.custom_cat.pelt.scars = ["NOPAW"]
+                                self.custom_cat.pelt.scars = ("NOPAW",)
                             else:
                                 if "NOPAW" in self.custom_cat.pelt.scars:
-                                    self.custom_cat.pelt.scars.remove("NOPAW")
+                                    self.custom_cat.pelt.scars = tuple()
 
                             if i[0] == "born without a tail":
-                                self.custom_cat.pelt.scars = ["NOTAIL"]
+                                self.custom_cat.pelt.scars = ("NOTAIL",)
                             else:
                                 if "NOTAIL" in self.custom_cat.pelt.scars:
-                                    self.custom_cat.pelt.scars.remove("NOTAIL")
+                                    self.custom_cat.pelt.scars = tuple()
                             
                             if i[0] != "blind":
                                 if "BOTHBLIND" in self.custom_cat.pelt.scars:
-                                    self.custom_cat.pelt.scars.remove("BOTHBLIND")
+                                    self.custom_cat.pelt.scars = tuple()
                             if i[0] != "one bad eye":
                                 if any(scar in ["LEFTBLIND", "RIGHTBLIND", "BRIGHTHEART"] for scar in self.custom_cat.pelt.scars):
-                                    self.custom_cat.pelt.scars = []
+                                    self.custom_cat.pelt.scars = tuple()
 
                             self.permanent_condition = i[0]
                         self.update_sprite()
@@ -3718,12 +3718,12 @@ class MakeClanScreen(Screens):
                     self.your_cat.permanent_condition['paralyzed']["moons_with"] = -1
                     self.your_cat.permanent_condition['paralyzed']['born_with'] = True
                 if self.permanent_condition is not None and self.permanent_condition == "born without a tail" and "NOTAIL" not in self.your_cat.pelt.scars:
-                    self.your_cat.pelt.scars.append('NOTAIL')
+                    self.your_cat.pelt.scars = ('NOTAIL',)
                     self.your_cat.permanent_condition['born without a tail']["moons_until"] = 1
                     self.your_cat.permanent_condition['born without a tail']["moons_with"] = -1
                     self.your_cat.permanent_condition['born without a tail']['born_with'] = True
                 elif self.permanent_condition is not None and self.permanent_condition == "born without a leg" and "NOPAW" not in self.your_cat.pelt.scars:
-                    self.your_cat.pelt.scars.append('NOPAW')
+                    self.your_cat.pelt.scars = ('NOPAW',)
                     self.your_cat.permanent_condition['born without a leg']["moons_until"] = 1
                     self.your_cat.permanent_condition['born without a leg']["moons_with"] = -1
                     self.your_cat.permanent_condition['born without a leg']['born_with'] = True

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -4080,6 +4080,7 @@ class MakeClanScreen(Screens):
                 else 
                 ("adult_long" + str(self.adult_pose))),
             senior_sprite="senior" + str(self.elder_pose),
+            para_adult_sprite= "para_adult_long0" if initial_pelt.length == "long" else "para_adult_short0",
             reverse=initial_pelt.reverse
         )
 

--- a/scripts/screens/TalkScreen.py
+++ b/scripts/screens/TalkScreen.py
@@ -121,7 +121,7 @@ class TalkScreen(Screens):
         text_options = self.dialogue_class.load_texts()
 
         self.chosen_text_key, self.chosen_text_value = (
-            self.dialogue_class.choose_dialogue(text_options)
+            self.dialogue_class.choose_dialogue(text_options, flirt=switch_get_value(Switch.talk_category) == "flirt")
             )
 
         self.chosen_text_object = {self.chosen_text_key: self.chosen_text_value}


### PR DESCRIPTION
- restored flirting because i completely forgot about it initially
- bugfix for dead cats-- alive_in_your_cat_group ignores dead residences now as intended
- converted scars from a list to a tuple in the customiser bc clangen changed theirs.... shakes fist at the sky
- fixed broken dialogue rank filtering
- fixed lg event generation buge that caused involved cat buttons to crash the game
- fixed customiser paralyzed sprite assignment
- fixed season, biome, and camp dialogue filters not working
- fixed dialogue debug only working once per moon